### PR TITLE
Inconsistent heights between sidebar and breadcrumb components

### DIFF
--- a/src/app/components/project-view/breadcrumb/breadcrumb.component.css
+++ b/src/app/components/project-view/breadcrumb/breadcrumb.component.css
@@ -14,7 +14,8 @@
 
     & .breadcrumb-link-name {
       text-decoration: none;
-      padding: 5px;
+      padding: 4px;
+      margin: 4px;
 
       & .breadcrumb-name {
         font-size: 13px;
@@ -44,7 +45,7 @@
     width: 50%;
 
     & .breadcrumb-ico {
-      padding: 2px 2px 0px 2px;
+      margin: 2px 2px 0px 2px;
     }
   }
 }

--- a/src/app/components/sidebar/sidebar.component.css
+++ b/src/app/components/sidebar/sidebar.component.css
@@ -15,11 +15,12 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
+      margin-top: 20px;
 
       & .sidebar-profile {
         display: flex;
         align-items: center;
-        padding: 10px 0;
+        /* padding: 10px 0; */
 
         & .profile-dropdown {
           position: relative;


### PR DESCRIPTION
This PR adjusts the vertical alignment of the Breadcrumb and Sidebar components. Previously, the components did not start at the same height, causing a visual inconsistency.
With this change:
- Both Breadcrumb and Sidebar now begin at the same height.
- The layout appears more consistent and visually aligned.