### PR TITLE
feat: created a star button that you can toggle to add or remove a favorite project

### DIFF
--- a/src/app/components/home/sidebar/menu-section/menu-section.component.css
+++ b/src/app/components/home/sidebar/menu-section/menu-section.component.css
@@ -53,6 +53,32 @@
                 gap: 10px;
             }
 
+            & .project-actions {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+
+                & .favorite-btn {
+                    background: none;
+                    border: none;
+                    cursor: pointer;
+                    padding: 2px;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    color: #ccc;
+                    transition: color 0.2s ease;
+
+                    &:hover {
+                        color: #ffc04a;
+                    }
+
+                    &.active {
+                        color: #ffc04a;
+                    }
+                }
+            }
+
             & .pending-tasks {
                 color: #5559;
                 font-size: 13px;

--- a/src/app/components/home/sidebar/menu-section/menu-section.component.html
+++ b/src/app/components/home/sidebar/menu-section/menu-section.component.html
@@ -35,7 +35,16 @@
                 }
                 <span>{{item.name}}</span>
             </div>
-            <span class="pending-tasks">{{item.pendingTasks}}</span>
+            <div class="project-actions">
+                @if (item.icon === 'project') {
+                <button class="favorite-btn" [class.active]="item.favorite" (click)="toggleFavorite(item.id, $event)" type="button">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+                    </svg>
+                </button>
+                }
+                <span class="pending-tasks">{{item.pendingTasks}}</span>
+            </div>
         </li>
         }
     </ul>

--- a/src/app/components/home/sidebar/menu-section/menu-section.component.ts
+++ b/src/app/components/home/sidebar/menu-section/menu-section.component.ts
@@ -1,8 +1,9 @@
-import { Component, input, signal } from '@angular/core';
+import { Component, input, signal, inject } from '@angular/core';
 import { NgClass, NgTemplateOutlet } from '@angular/common';
 import { TWDSidebarMenu } from '../../../../shared/models/sidebar-menu';
 import { ModalService } from '../../../../services/modal.service';
 import { TWDModalType } from '../../../../shared/models/modals-type';
+import { ProjectStore } from '../../../../features/projects/presentation/store/project.store';
 
 @Component({
   selector: 'sidebar-menu-section',
@@ -13,6 +14,8 @@ import { TWDModalType } from '../../../../shared/models/modals-type';
 export class MenuSectionComponent {
   public menuSectionInfo = input.required<TWDSidebarMenu>()
   public showPlusIcon = input<boolean>(false)
+
+  private projectStore = inject(ProjectStore);
 
   constructor(private modalService: ModalService) { }
 
@@ -31,5 +34,12 @@ export class MenuSectionComponent {
   openModal(type: TWDModalType, title: string) {
     console.log('click');
     this.modalService.open(type, { title });
+  }
+
+  toggleFavorite(projectId: string | undefined, event: Event): void {
+    event.stopPropagation();
+    if (!projectId) return;
+
+    this.projectStore.toggleProjectFavorite(projectId);
   }
 }

--- a/src/app/components/home/sidebar/sidebar.component.ts
+++ b/src/app/components/home/sidebar/sidebar.component.ts
@@ -67,14 +67,14 @@ export class SidebarComponent {
     items: this.projects()
       .filter((p) => p.favorite)
       .map((p) => {
-        return { name: p.name, pendingTasks: p.pendingTasks, icon: 'project' };
+        return { id: p.id, name: p.name, pendingTasks: p.pendingTasks, icon: 'project', favorite: p.favorite };
       }),
   }));
 
   protected projectsMenuSectionInfo = computed<TWDSidebarMenu>(() => ({
     title: 'My Projects',
     items: this.projects().map((p) => {
-      return { name: p.name, pendingTasks: p.pendingTasks, icon: 'project' };
+      return { id: p.id, name: p.name, pendingTasks: p.pendingTasks, icon: 'project', favorite: p.favorite };
     }),
   }));
 }

--- a/src/app/features/projects/application/use-cases/toggle-favorite.use-case.ts
+++ b/src/app/features/projects/application/use-cases/toggle-favorite.use-case.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ProjectRepository } from '../../domain/repositories/project.repository';
+
+@Injectable()
+export class ToggleFavoriteUseCase {
+  constructor(private projectRepository: ProjectRepository) {}
+
+  execute(projectId: string, favorite: boolean): Observable<void> {
+    return this.projectRepository.toggleFavorite(projectId, favorite);
+  }
+}

--- a/src/app/features/projects/domain/repositories/project.repository.ts
+++ b/src/app/features/projects/domain/repositories/project.repository.ts
@@ -16,4 +16,5 @@ export abstract class ProjectRepository {
   abstract getAll(): Observable<Project[]>;
   abstract update(project: ProjectDto): Observable<Project>;
   abstract delete(projectId: string): Observable<void>;
+  abstract toggleFavorite(projectId: string, favorite: boolean): Observable<void>;
 }

--- a/src/app/features/projects/infrastructure/repositories/http-project.repository.ts
+++ b/src/app/features/projects/infrastructure/repositories/http-project.repository.ts
@@ -42,4 +42,8 @@ export class HttpProjectRepository extends ProjectRepository {
   delete(projectId: string): Observable<void> {
     return this.http.delete<void>(`${this.baseUrl}/${projectId}/delete`);
   }
+
+  toggleFavorite(projectId: string, favorite: boolean): Observable<void> {
+    return this.http.put<void>(`${this.baseUrl}/${projectId}/favorite`, { favorite });
+  }
 }

--- a/src/app/features/projects/projects.providers.ts
+++ b/src/app/features/projects/projects.providers.ts
@@ -10,6 +10,7 @@ import { LoadAllProjectsUseCase } from './application/use-cases/load-all-project
 import { CreateSectionUseCase } from './application/use-cases/create-section.use-case';
 import { CreateTaskUseCase } from './application/use-cases/create-task.use-case';
 import { ToggleTaskCompletionUseCase } from './application/use-cases/toggle-task-completion.use-case';
+import { ToggleFavoriteUseCase } from './application/use-cases/toggle-favorite.use-case';
 import { CreateProjectUseCase } from './application/use-cases/create-project.use-case';
 import { ProjectStore } from './presentation/store/project.store';
 import { SectionStore } from './presentation/store/section.store';
@@ -28,6 +29,7 @@ export const PROJECT_FEATURE_PROVIDERS: Provider[] = [
   CreateSectionUseCase,
   CreateTaskUseCase,
   ToggleTaskCompletionUseCase,
+  ToggleFavoriteUseCase,
 
   // Presentation — Stores
   ProjectStore,

--- a/src/app/shared/models/sidebar-menu.ts
+++ b/src/app/shared/models/sidebar-menu.ts
@@ -1,4 +1,5 @@
 export interface TWDSidebarMenuItem {
+  id?: string;
   name: string;
   pendingTasks: number;
   icon?: string;


### PR DESCRIPTION
This pull request introduces a "favorite" feature for projects, allowing users to mark projects as favorites directly from the sidebar. The implementation includes UI updates for toggling favorites, state management enhancements, and backend integration for persisting favorite status.

**UI and UX Enhancements:**

* Added a favorite button (star icon) to each project in the sidebar, with visual feedback for active (favorited) state and hover effect.
* Updated the sidebar menu item model to include a project `id` and `favorite` status, enabling correct toggling and display. 

**State Management and Store Updates:**

* Extended the `ProjectStore` with a `toggleProjectFavorite` method, which optimistically updates the favorite status in the store and handles error cases. (`project.store.ts`)
* Injected the necessary use case and updated the store's dependency providers to support the new toggle favorite functionality.

**Domain and Backend Integration:**

* Added a new `ToggleFavoriteUseCase` to encapsulate the favorite toggling logic. (`toggle-favorite.use-case.ts`)
* Updated the `ProjectRepository` interface and its HTTP implementation to support toggling a project's favorite status via the backend.