### PR TITLE
feat: implement project selection in sidebar and auto-select first project if nonde is selected

### DIFF
--- a/src/app/features/projects/presentation/components/home/project-view/project-view.component.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-view.component.ts
@@ -26,9 +26,6 @@ export class ProjectViewComponent implements OnInit {
   protected projectInfo = computed(() => this.projectStore.projectView());
 
   ngOnInit(): void {
-    // Load project - in real app, get ID from route params
-    this.projectStore.loadProject('1');
-    // Load all projects on component initialization
     this.projectStore.loadAllProjects();
   }
 

--- a/src/app/features/projects/presentation/components/home/sidebar/menu-section/menu-section.component.html
+++ b/src/app/features/projects/presentation/components/home/sidebar/menu-section/menu-section.component.html
@@ -19,7 +19,7 @@
     </div>
     <ul>
         @for (item of menuSectionInfo().items; track $index) {
-        <li class="sidebar-hover">
+        <li class="sidebar-hover" (click)="selectProject(item.id)">
             <div class="project-start">
                 @switch (item.icon){
                 @case ('project') {

--- a/src/app/features/projects/presentation/components/home/sidebar/menu-section/menu-section.component.ts
+++ b/src/app/features/projects/presentation/components/home/sidebar/menu-section/menu-section.component.ts
@@ -36,6 +36,11 @@ export class MenuSectionComponent {
     this.modalService.open(type, { title });
   }
 
+  selectProject(projectId: string | undefined): void {
+    if (!projectId) return;
+    this.projectStore.loadProject(projectId);
+  }
+
   toggleFavorite(projectId: string | undefined, event: Event): void {
     event.stopPropagation();
     if (!projectId) return;

--- a/src/app/features/projects/presentation/store/project.store.ts
+++ b/src/app/features/projects/presentation/store/project.store.ts
@@ -237,6 +237,12 @@ export class ProjectStore {
           projects: projectsDict,
           loading: false,
         }));
+
+        // Auto-select the first project if none is selected yet
+        const ids = Object.keys(projectsDict);
+        if (!this.state().selectedProjectId && ids.length > 0) {
+          this.loadProject(ids[0]);
+        }
       },
       error: (error) => {
         this.state.update(s => ({ ...s, loading: false }));


### PR DESCRIPTION
This pull request improves project selection behavior in the project view and sidebar menu. The main changes ensure that the project list loads on initialization, users can select projects from the sidebar, and the first project is auto-selected if none is already chosen.

Enhancements to project selection:

* The sidebar menu now allows users to select a project by clicking on its entry, triggering the loading of the selected project via the `selectProject` method in `MenuSectionComponent`. 
* In `ProjectStore`, after loading all projects, the first project is automatically selected if no project is currently selected.

Initialization behavior updates:

* The project view component now only loads all projects on initialization, removing the previous hardcoded loading of a single project.