### PR TITLE
Cancel project creation

### DIFF
--- a/src/app/features/projects/presentation/components/create-project/create-project.component.html
+++ b/src/app/features/projects/presentation/components/create-project/create-project.component.html
@@ -12,12 +12,12 @@
           <input type="checkbox" formControlName="favorite">
           <span class="slider"></span>
         </label>
-        <div>Añadir a Favoritos</div>
+        <div>Add to Favorites</div>
       </div>
     </div>
     <hr>
     <div class="create-project-buttons-section">
-      <button class="cancel" type="button" (click)="cancel()">Cancelar</button>
+      <button class="cancel" type="button" (click)="cancel()">Cancel</button>
       <button class="create" type="submit">Create Project</button>
     </div>
 

--- a/src/app/features/projects/presentation/components/create-project/create-project.component.ts
+++ b/src/app/features/projects/presentation/components/create-project/create-project.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, output } from '@angular/core';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ProjectStore } from '@features/projects/presentation/store/project.store';
 
@@ -17,6 +17,8 @@ export class CreateProjectComponent {
     favorite: new FormControl<boolean>(false, { nonNullable: true }),
   });
 
+  public closeModal = output<void>();
+
   private projectStore = inject(ProjectStore);
 
   create() {
@@ -26,7 +28,7 @@ export class CreateProjectComponent {
     });
   }
 
-  cancel(){
-    //TODO Logic for closing the login modal
+  cancel() {
+    this.closeModal.emit();
   }
 }

--- a/src/app/shared/ui/modal/modal.component.html
+++ b/src/app/shared/ui/modal/modal.component.html
@@ -14,7 +14,7 @@
     <profile-modal />
     }
     @case ('create-project') {
-    <create-project-modal />
+    <create-project-modal (closeModal)="close()" />
     }
     }
   </div>


### PR DESCRIPTION
The implementation of the project creation modal was still missing the logic for closing the modal. 

Solved this TODO. 