### PR TITLE
fix: also closing modal automatically when finished creating project

### DIFF
--- a/src/app/features/projects/presentation/components/create-project/create-project.component.ts
+++ b/src/app/features/projects/presentation/components/create-project/create-project.component.ts
@@ -26,6 +26,7 @@ export class CreateProjectComponent {
       name: this.createProjetForm.controls.projectName.value,
       favorite: this.createProjetForm.controls.favorite.value,
     });
+    this.closeModal.emit();
   }
 
   cancel() {


### PR DESCRIPTION
This is an extension feature from the #52 PR. Closing modal automatically when the project is created