### PR TITLE
Add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
This pull request adds a .gitattributes file to normalize text file line endings to LF across environments.

Added .gitattributes with * text=auto eol=lf.
Prevents recurring modified changes caused by LF/CRLF differences on different operating systems.