### PR TITLE
Refactor/project domain errors

### DIFF
--- a/src/app/features/projects/application/errors/projects.error.ts
+++ b/src/app/features/projects/application/errors/projects.error.ts
@@ -1,0 +1,9 @@
+export type ProjectsError =
+  | { code: 'PROJECT_NAME_REQUIRED' }
+  | { code: 'PROJECT_NAME_TOO_SHORT'; min: number }
+  | { code: 'PROJECT_NAME_TOO_LONG'; max: number }
+  | { code: 'SECTION_NAME_REQUIRED' }
+  | { code: 'SECTION_NAME_TOO_SHORT'; min: number }
+  | { code: 'SECTION_NAME_TOO_LONG'; max: number }
+  | { code: 'NETWORK_ERROR' }
+  | { code: 'UNEXPECTED_ERROR' };

--- a/src/app/features/projects/application/errors/projects.error.ts
+++ b/src/app/features/projects/application/errors/projects.error.ts
@@ -5,5 +5,8 @@ export type ProjectsError =
   | { code: 'SECTION_NAME_REQUIRED' }
   | { code: 'SECTION_NAME_TOO_SHORT'; min: number }
   | { code: 'SECTION_NAME_TOO_LONG'; max: number }
+  | { code: 'TASK_NAME_REQUIRED' }
+  | { code: 'TASK_NAME_TOO_SHORT'; min: number }
+  | { code: 'TASK_NAME_TOO_LONG'; max: number }
   | { code: 'NETWORK_ERROR' }
   | { code: 'UNEXPECTED_ERROR' };

--- a/src/app/features/projects/application/use-cases/projects/create-project/create-project.use-case.spec.ts
+++ b/src/app/features/projects/application/use-cases/projects/create-project/create-project.use-case.spec.ts
@@ -8,8 +8,17 @@ import { ProjectRepository } from '@features/projects/domain/repositories/projec
 import { Project } from '@features/projects/domain/entities/project.entity';
 import { ProjectName } from '@features/projects/domain/value-objects/project-name.value-object';
 
+function validProjectName(value: string): ProjectName {
+  const result = ProjectName.tryCreate(value);
+  if (!result.success) {
+    throw new Error('Invalid test project name');
+  }
+
+  return result.value;
+}
+
 const input = { name: 'NN', favorite: true };
-const created = new Project('new-id', ProjectName.create('NN'), true, []);
+const created = new Project('new-id', validProjectName('NN'), true, []);
 
 describe('CreateProjectUseCase', () => {
   let useCase: CreateProjectUseCase;

--- a/src/app/features/projects/application/use-cases/projects/create-project/create-project.use-case.spec.ts
+++ b/src/app/features/projects/application/use-cases/projects/create-project/create-project.use-case.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { beforeEach, describe, it, expect, vi } from 'vitest';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 import { CreateProjectUseCase } from './create-project.use-case';
 import { ProjectRepository } from '@features/projects/domain/repositories/project.repository';
@@ -30,7 +30,10 @@ describe('CreateProjectUseCase', () => {
   });
 
   it('validates name, builds Project and delegates to projectRepository.create', () => {
-    const expectedOutput = { id: 'new-id', name: 'NN', favorite: true, sectionIds: [] };
+    const expectedOutput = {
+      success: true,
+      value: { id: 'new-id', name: 'NN', favorite: true, sectionIds: [] },
+    };
 
     useCase.execute(input).subscribe((out) => expect(out).toEqual(expectedOutput));
     expect(repo.create).toHaveBeenCalled();
@@ -40,8 +43,19 @@ describe('CreateProjectUseCase', () => {
     expect(arg.favorite).toBe(true);
   });
 
-  it('throws when name violates ProjectName rules', () => {
-    expect(() => useCase.execute({ name: '', favorite: false })).toThrow('Project name is required');
+  it('returns validation error result when name violates ProjectName rules', () => {
+    useCase.execute({ name: '', favorite: false }).subscribe((result) => {
+      expect(result).toEqual({ success: false, error: { code: 'PROJECT_NAME_REQUIRED' } });
+    });
+
     expect(repo.create).not.toHaveBeenCalled();
+  });
+
+  it('maps repository failures to NETWORK_ERROR', () => {
+    (repo.create as ReturnType<typeof vi.fn>).mockReturnValue(throwError(() => new Error('boom')));
+
+    useCase.execute(input).subscribe((result) => {
+      expect(result).toEqual({ success: false, error: { code: 'NETWORK_ERROR' } });
+    });
   });
 });

--- a/src/app/features/projects/application/use-cases/projects/create-project/create-project.use-case.ts
+++ b/src/app/features/projects/application/use-cases/projects/create-project/create-project.use-case.ts
@@ -1,10 +1,12 @@
 import { inject, Injectable } from "@angular/core";
 import { ProjectRepository } from "@features/projects/domain/repositories/project.repository";
-import { Observable } from "rxjs";
+import { Observable, of } from "rxjs";
 import { Project } from "@features/projects/domain/entities/project.entity";
 import { ProjectName } from "@features/projects/domain/value-objects/project-name.value-object";
 import { toProjectOutput } from '@features/projects/application/mappers/project-output.mapper';
-import { map } from "rxjs/operators";
+import { catchError, map } from "rxjs/operators";
+import { Result, fail, ok } from '@shared/utils/result';
+import { ProjectsError } from '@features/projects/application/errors/projects.error';
 
 export interface CreateProjectInput {
   name: string;
@@ -20,14 +22,20 @@ export interface CreateProjectOutput {
 
 @Injectable()
 export class CreateProjectUseCase {
-  private projectRepository = inject(ProjectRepository);
+  private readonly projectRepository = inject(ProjectRepository);
 
-  execute(input: CreateProjectInput): Observable<CreateProjectOutput> {
-    const projectName = ProjectName.create(input.name);
+  execute(input: CreateProjectInput): Observable<Result<CreateProjectOutput, ProjectsError>> {
+    const projectNameResult = ProjectName.tryCreate(input.name);
+    if (!projectNameResult.success) {
+      return of(fail(projectNameResult.error));
+    }
+
+    const projectName = projectNameResult.value;
     const project = Project.create(projectName, input.favorite);
 
     return this.projectRepository.create(project).pipe(
-      map((saved) => toProjectOutput(saved, [])),
+      map((saved): Result<CreateProjectOutput, ProjectsError> => ok(toProjectOutput(saved, []))),
+      catchError(() => of(fail<ProjectsError>({ code: 'NETWORK_ERROR' }))),
     );
   }
 }

--- a/src/app/features/projects/application/use-cases/projects/load-all-projects/load-all-projects.use-case.spec.ts
+++ b/src/app/features/projects/application/use-cases/projects/load-all-projects/load-all-projects.use-case.spec.ts
@@ -8,8 +8,17 @@ import { ProjectRepository, ProjectSummary } from '@features/projects/domain/rep
 import { Project } from '@features/projects/domain/entities/project.entity';
 import { ProjectName } from '@features/projects/domain/value-objects/project-name.value-object';
 
+function validProjectName(value: string): ProjectName {
+  const result = ProjectName.tryCreate(value);
+  if (!result.success) {
+    throw new Error('Invalid test project name');
+  }
+
+  return result.value;
+}
+
 const summaries: ProjectSummary[] = [
-  { project: new Project('1', ProjectName.create('AA'), false, []), pendingCount: 2 },
+  { project: new Project('1', validProjectName('AA'), false, []), pendingCount: 2 },
 ];
 
 describe('LoadAllProjectsUseCase', () => {

--- a/src/app/features/projects/application/use-cases/projects/load-project/load-project.use-case.spec.ts
+++ b/src/app/features/projects/application/use-cases/projects/load-project/load-project.use-case.spec.ts
@@ -8,8 +8,17 @@ import { ProjectRepository, ProjectAggregate } from '@features/projects/domain/r
 import { Project } from '@features/projects/domain/entities/project.entity';
 import { ProjectName } from '@features/projects/domain/value-objects/project-name.value-object';
 
+function validProjectName(value: string): ProjectName {
+  const result = ProjectName.tryCreate(value);
+  if (!result.success) {
+    throw new Error('Invalid test project name');
+  }
+
+  return result.value;
+}
+
 const aggregate: ProjectAggregate = {
-  project: new Project('p1', ProjectName.create('PP'), false, []),
+  project: new Project('p1', validProjectName('PP'), false, []),
   sections: [],
   tasks: [],
 };

--- a/src/app/features/projects/application/use-cases/projects/update-project/update-project.use-case.spec.ts
+++ b/src/app/features/projects/application/use-cases/projects/update-project/update-project.use-case.spec.ts
@@ -8,6 +8,15 @@ import { ProjectRepository } from '@features/projects/domain/repositories/projec
 import { Project } from '@features/projects/domain/entities/project.entity';
 import { ProjectName } from '@features/projects/domain/value-objects/project-name.value-object';
 
+function validProjectName(value: string): ProjectName {
+  const result = ProjectName.tryCreate(value);
+  if (!result.success) {
+    throw new Error('Invalid test project name');
+  }
+
+  return result.value;
+}
+
 describe('UpdateProjectUseCase', () => {
   let useCase: UpdateProjectUseCase;
   let repo: Partial<ProjectRepository>;
@@ -29,7 +38,7 @@ describe('UpdateProjectUseCase', () => {
   });
 
   it('validates name, builds Project and delegates to projectRepository.update', () => {
-    const saved = new Project('p1', ProjectName.create('New Name'), true, ['s1']);
+    const saved = new Project('p1', validProjectName('New Name'), true, ['s1']);
     (repo.update as ReturnType<typeof vi.fn>).mockReturnValue(of(saved));
 
     const input = { id: 'p1', name: 'New Name', favorite: true, sectionIds: ['s1'] };

--- a/src/app/features/projects/application/use-cases/projects/update-project/update-project.use-case.spec.ts
+++ b/src/app/features/projects/application/use-cases/projects/update-project/update-project.use-case.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 import { UpdateProjectUseCase } from './update-project.use-case';
 import { ProjectRepository } from '@features/projects/domain/repositories/project.repository';
@@ -33,7 +33,10 @@ describe('UpdateProjectUseCase', () => {
     (repo.update as ReturnType<typeof vi.fn>).mockReturnValue(of(saved));
 
     const input = { id: 'p1', name: 'New Name', favorite: true, sectionIds: ['s1'] };
-    const expectedOutput = { id: 'p1', name: 'New Name', favorite: true, sectionIds: ['s1'] };
+    const expectedOutput = {
+      success: true,
+      value: { id: 'p1', name: 'New Name', favorite: true, sectionIds: ['s1'] },
+    };
 
     useCase.execute(input).subscribe((out) => expect(out).toEqual(expectedOutput));
 
@@ -45,12 +48,20 @@ describe('UpdateProjectUseCase', () => {
     expect(arg.favorite).toBe(true);
   });
 
-  it('throws when name violates ProjectName rules', () => {
-    expect(() =>
-      useCase.execute({ id: 'p1', name: '', favorite: false, sectionIds: [] }),
-    ).toThrow('Project name is required');
+  it('returns validation error result when name violates ProjectName rules', () => {
+    useCase.execute({ id: 'p1', name: '', favorite: false, sectionIds: [] }).subscribe((result) => {
+      expect(result).toEqual({ success: false, error: { code: 'PROJECT_NAME_REQUIRED' } });
+    });
 
     expect(repo.update).not.toHaveBeenCalled();
+  });
+
+  it('maps repository failures to NETWORK_ERROR', () => {
+    (repo.update as ReturnType<typeof vi.fn>).mockReturnValue(throwError(() => new Error('boom')));
+
+    useCase.execute({ id: 'p1', name: 'New Name', favorite: true, sectionIds: [] }).subscribe((result) => {
+      expect(result).toEqual({ success: false, error: { code: 'NETWORK_ERROR' } });
+    });
   });
 });
 

--- a/src/app/features/projects/application/use-cases/projects/update-project/update-project.use-case.ts
+++ b/src/app/features/projects/application/use-cases/projects/update-project/update-project.use-case.ts
@@ -1,11 +1,13 @@
 import { inject, Injectable } from "@angular/core";
 import { ProjectRepository } from "@features/projects/domain/repositories/project.repository";
-import { Observable } from "rxjs";
+import { Observable, of } from "rxjs";
 import { Project } from "@features/projects/domain/entities/project.entity";
 import { ProjectName } from "@features/projects/domain/value-objects/project-name.value-object";
 import { toProjectOutput } from '@features/projects/application/mappers/project-output.mapper';
-import { map } from "rxjs/operators";
+import { catchError, map } from "rxjs/operators";
 import { ProjectOutput } from "@features/projects/application/dtos/project-output";
+import { Result, fail, ok } from '@shared/utils/result';
+import { ProjectsError } from '@features/projects/application/errors/projects.error';
 
 export interface UpdateProjectInput {
   id: string;
@@ -16,17 +18,23 @@ export interface UpdateProjectInput {
 
 @Injectable()
 export class UpdateProjectUseCase {
-  private projectRepository = inject(ProjectRepository);
+  private readonly projectRepository = inject(ProjectRepository);
 
-  execute(input: UpdateProjectInput): Observable<ProjectOutput> {
-    const projectName = ProjectName.create(input.name);
+  execute(input: UpdateProjectInput): Observable<Result<ProjectOutput, ProjectsError>> {
+    const projectNameResult = ProjectName.tryCreate(input.name);
+    if (!projectNameResult.success) {
+      return of(fail(projectNameResult.error));
+    }
+
+    const projectName = projectNameResult.value;
     const project = new Project(input.id, projectName, input.favorite, input.sectionIds);
 
     return this.projectRepository.update(project).pipe(
-      map((saved) => ({
-        ...toProjectOutput(saved, []),
-        sectionIds: [...input.sectionIds],
-      })),
+      map((saved): Result<ProjectOutput, ProjectsError> => ok({
+          ...toProjectOutput(saved, []),
+          sectionIds: [...input.sectionIds],
+        })),
+      catchError(() => of(fail<ProjectsError>({ code: 'NETWORK_ERROR' }))),
     );
   }
 }

--- a/src/app/features/projects/application/use-cases/sections/create-section/create-section.use-case.spec.ts
+++ b/src/app/features/projects/application/use-cases/sections/create-section/create-section.use-case.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { beforeEach, describe, it, expect, vi } from 'vitest';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 import { CreateSectionUseCase } from './create-section.use-case';
 import { SectionRepository } from '@features/projects/domain/repositories/section.repository';
@@ -31,12 +31,31 @@ describe('CreateSectionUseCase', () => {
   });
 
   it('builds Section via Section.create and calls sectionRepository.create', () => {
-    let result: Section | undefined;
+    let result: { success: true; value: Section } | { success: false; error: unknown } | undefined;
     useCase.execute('p1', 'Sprint 1').subscribe((s) => (result = s));
     expect(sectionRepo.create).toHaveBeenCalled();
     const arg = (sectionRepo.create as ReturnType<typeof vi.fn>).mock.calls[0][0] as Section;
     expect(arg.name).toBe('Sprint 1');
     expect(arg.projectId).toBe('p1');
-    expect(result?.id).toBe('s-new');
+    expect(result?.success).toBe(true);
+    if (result?.success) {
+      expect(result.value.id).toBe('s-new');
+    }
+  });
+
+  it('returns validation result when section name is invalid', () => {
+    useCase.execute('p1', '').subscribe((result) => {
+      expect(result).toEqual({ success: false, error: { code: 'SECTION_NAME_REQUIRED' } });
+    });
+
+    expect(sectionRepo.create).not.toHaveBeenCalled();
+  });
+
+  it('maps repository failures to NETWORK_ERROR', () => {
+    (sectionRepo.create as ReturnType<typeof vi.fn>).mockReturnValue(throwError(() => new Error('boom')));
+
+    useCase.execute('p1', 'Sprint 1').subscribe((result) => {
+      expect(result).toEqual({ success: false, error: { code: 'NETWORK_ERROR' } });
+    });
   });
 });

--- a/src/app/features/projects/application/use-cases/sections/create-section/create-section.use-case.ts
+++ b/src/app/features/projects/application/use-cases/sections/create-section/create-section.use-case.ts
@@ -1,23 +1,27 @@
 import { Injectable, inject } from '@angular/core';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 import { Section } from '@features/projects/domain/entities/section.entity';
 import { SectionRepository } from '@features/projects/domain/repositories/section.repository';
-import { ProjectRepository } from '@features/projects/domain/repositories/project.repository';
+import { Result, fail, ok } from '@shared/utils/result';
+import { ProjectsError } from '@features/projects/application/errors/projects.error';
+import { SectionName } from '@features/projects/domain/value-objects/section-name.value-object';
 
 @Injectable()
 export class CreateSectionUseCase {
-  private sectionRepository = inject(SectionRepository);
-  private projectRepository = inject(ProjectRepository);
+  private readonly sectionRepository = inject(SectionRepository);
 
 
-  execute(projectId: string, sectionName: string): Observable<Section> {
-    const section = Section.create(sectionName, projectId);
+  execute(projectId: string, sectionName: string): Observable<Result<Section, ProjectsError>> {
+    const sectionNameResult = SectionName.tryCreate(sectionName);
+    if (!sectionNameResult.success) {
+      return of(fail(sectionNameResult.error));
+    }
+
+    const section = new Section(crypto.randomUUID(), sectionNameResult.value.value, projectId, []);
     return this.sectionRepository.create(section).pipe(
-      map(createdSection => {
-        // Note: Project update to add section ID would be handled separately
-        return createdSection;
-      })
+      map((createdSection): Result<Section, ProjectsError> => ok(createdSection)),
+      catchError(() => of(fail<ProjectsError>({ code: 'NETWORK_ERROR' }))),
     );
   }
 }

--- a/src/app/features/projects/application/use-cases/sections/update-section/update-section.use-case.spec.ts
+++ b/src/app/features/projects/application/use-cases/sections/update-section/update-section.use-case.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { beforeEach, describe, it, expect, vi } from 'vitest';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 import { UpdateSectionUseCase } from './update-section.use-case';
 import { SectionRepository } from '@features/projects/domain/repositories/section.repository';
@@ -32,7 +32,10 @@ describe('UpdateSectionUseCase', () => {
     (repo.update as ReturnType<typeof vi.fn>).mockReturnValue(of(saved));
 
     const input = { id: 's1', name: 'Renamed', projectId: 'p1' };
-    const expectedOutput = { id: 's1', name: 'Renamed', projectId: 'p1', taskIds: ['t1'] };
+    const expectedOutput = {
+      success: true,
+      value: { id: 's1', name: 'Renamed', projectId: 'p1', taskIds: ['t1'] },
+    };
 
     useCase.execute(input).subscribe((out) => expect(out).toEqual(expectedOutput));
 
@@ -42,5 +45,21 @@ describe('UpdateSectionUseCase', () => {
     expect(arg.id).toBe('s1');
     expect(arg.name).toBe('Renamed');
     expect(arg.projectId).toBe('p1');
+  });
+
+  it('returns validation result when section name is invalid', () => {
+    useCase.execute({ id: 's1', name: '', projectId: 'p1' }).subscribe((result) => {
+      expect(result).toEqual({ success: false, error: { code: 'SECTION_NAME_REQUIRED' } });
+    });
+
+    expect(repo.update).not.toHaveBeenCalled();
+  });
+
+  it('maps repository failures to NETWORK_ERROR', () => {
+    (repo.update as ReturnType<typeof vi.fn>).mockReturnValue(throwError(() => new Error('boom')));
+
+    useCase.execute({ id: 's1', name: 'Renamed', projectId: 'p1' }).subscribe((result) => {
+      expect(result).toEqual({ success: false, error: { code: 'NETWORK_ERROR' } });
+    });
   });
 });

--- a/src/app/features/projects/application/use-cases/sections/update-section/update-section.use-case.ts
+++ b/src/app/features/projects/application/use-cases/sections/update-section/update-section.use-case.ts
@@ -1,11 +1,13 @@
 import { Injectable, inject } from '@angular/core';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 import { SectionRepository } from '@features/projects/domain/repositories/section.repository';
 import { Section } from '@features/projects/domain/entities/section.entity';
 import { SectionName } from '@features/projects/domain/value-objects/section-name.value-object';
 import { SectionOutput } from '@features/projects/application/dtos/section-output';
 import { toSectionOutput } from '@features/projects/application/mappers/section-output.mapper';
+import { Result, fail, ok } from '@shared/utils/result';
+import { ProjectsError } from '@features/projects/application/errors/projects.error';
 
 export interface UpdateSectionInput {
   id: string;
@@ -15,13 +17,18 @@ export interface UpdateSectionInput {
 
 @Injectable()
 export class UpdateSectionUseCase {
-  private sectionRepository = inject(SectionRepository);
+  private readonly sectionRepository = inject(SectionRepository);
 
-  execute(input: UpdateSectionInput): Observable<SectionOutput> {
-    const sectionName = SectionName.create(input.name);
-    const section = new Section(input.id, sectionName.value, input.projectId, []);
+  execute(input: UpdateSectionInput): Observable<Result<SectionOutput, ProjectsError>> {
+    const sectionNameResult = SectionName.tryCreate(input.name);
+    if (!sectionNameResult.success) {
+      return of(fail(sectionNameResult.error));
+    }
+
+    const section = new Section(input.id, sectionNameResult.value.value, input.projectId, []);
     return this.sectionRepository.update(section).pipe(
-      map(toSectionOutput),
+      map((saved): Result<SectionOutput, ProjectsError> => ok(toSectionOutput(saved))),
+      catchError(() => of(fail<ProjectsError>({ code: 'NETWORK_ERROR' }))),
     );
   }
 }

--- a/src/app/features/projects/application/use-cases/tasks/create-task/create-task.use-case.spec.ts
+++ b/src/app/features/projects/application/use-cases/tasks/create-task/create-task.use-case.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { beforeEach, describe, it, expect, vi } from 'vitest';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 import { CreateTaskUseCase } from './create-task.use-case';
 import { TaskRepository } from '@features/projects/domain/repositories/task.repository';
@@ -28,10 +28,32 @@ describe('CreateTaskUseCase', () => {
   });
 
   it('delegates Task.create output to taskRepository.create', () => {
-    useCase.execute('p1', 'sec-1', 'Task A', start).subscribe((t) => expect(t.id).toBe('t-new'));
+    useCase.execute('p1', 'sec-1', 'Task A', start).subscribe((result) => {
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.value.id).toBe('t-new');
+      }
+    });
+
     expect(repo.create).toHaveBeenCalled();
     const taskArg = (repo.create as ReturnType<typeof vi.fn>).mock.calls[0][1] as Task;
     expect(taskArg.name).toBe('Task A');
     expect(taskArg.sectionId).toBe('sec-1');
+  });
+
+  it('returns validation error result when task name is invalid', () => {
+    useCase.execute('p1', 'sec-1', '').subscribe((result) => {
+      expect(result).toEqual({ success: false, error: { code: 'TASK_NAME_REQUIRED' } });
+    });
+
+    expect(repo.create).not.toHaveBeenCalled();
+  });
+
+  it('maps repository failures to NETWORK_ERROR', () => {
+    (repo.create as ReturnType<typeof vi.fn>).mockReturnValue(throwError(() => new Error('boom')));
+
+    useCase.execute('p1', 'sec-1', 'Task A', start).subscribe((result) => {
+      expect(result).toEqual({ success: false, error: { code: 'NETWORK_ERROR' } });
+    });
   });
 });

--- a/src/app/features/projects/application/use-cases/tasks/create-task/create-task.use-case.ts
+++ b/src/app/features/projects/application/use-cases/tasks/create-task/create-task.use-case.ts
@@ -1,15 +1,32 @@
 import { Injectable, inject } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 import { Task } from '@features/projects/domain/entities/task.entity';
 import { TaskRepository } from '@features/projects/domain/repositories/task.repository';
+import { Result, fail, ok } from '@shared/utils/result';
+import { ProjectsError } from '@features/projects/application/errors/projects.error';
+import { TaskName } from '@features/projects/domain/value-objects/task-name.value-object';
 
 @Injectable()
 export class CreateTaskUseCase {
-  private taskRepository = inject(TaskRepository);
+  private readonly taskRepository = inject(TaskRepository);
 
 
-  execute(projectId: string, sectionId: string, taskName: string, startDate: Date = new Date()): Observable<Task> {
-    const task = Task.create(taskName, sectionId, startDate);
-    return this.taskRepository.create(projectId, task);
+  execute(
+    projectId: string,
+    sectionId: string,
+    taskName: string,
+    startDate: Date = new Date(),
+  ): Observable<Result<Task, ProjectsError>> {
+    const taskNameResult = TaskName.tryCreate(taskName);
+    if (!taskNameResult.success) {
+      return of(fail(taskNameResult.error));
+    }
+
+    const task = Task.create(taskNameResult.value.value, sectionId, startDate);
+    return this.taskRepository.create(projectId, task).pipe(
+      map((created): Result<Task, ProjectsError> => ok(created)),
+      catchError(() => of(fail<ProjectsError>({ code: 'NETWORK_ERROR' }))),
+    );
   }
 }

--- a/src/app/features/projects/application/use-cases/tasks/update-task/update-task.use-case.spec.ts
+++ b/src/app/features/projects/application/use-cases/tasks/update-task/update-task.use-case.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { beforeEach, describe, it, expect, vi } from 'vitest';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 import { Task } from '@features/projects/domain/entities/task.entity';
 import { TaskRepository } from '@features/projects/domain/repositories/task.repository';
@@ -31,10 +31,32 @@ describe('UpdateTaskUseCase', () => {
   it('delegates to taskRepository.update', () => {
     const task = Task.create('Original', 'sec-1', new Date('2025-01-01'), 'task-1').updateName('Updated');
 
-    useCase.execute('p1', task).subscribe((updated) => {
-      expect(updated.name).toBe('Updated');
+    useCase.execute('p1', task).subscribe((result) => {
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.value.name).toBe('Updated');
+      }
     });
 
     expect(repo.update).toHaveBeenCalledWith('p1', task);
+  });
+
+  it('returns validation error result when task name is invalid', () => {
+    const task = Task.create('Original', 'sec-1', new Date('2025-01-01'), 'task-1').updateName('');
+
+    useCase.execute('p1', task).subscribe((result) => {
+      expect(result).toEqual({ success: false, error: { code: 'TASK_NAME_REQUIRED' } });
+    });
+
+    expect(repo.update).not.toHaveBeenCalled();
+  });
+
+  it('maps repository failures to NETWORK_ERROR', () => {
+    const task = Task.create('Original', 'sec-1', new Date('2025-01-01'), 'task-1').updateName('Updated');
+    (repo.update as ReturnType<typeof vi.fn>).mockReturnValue(throwError(() => new Error('boom')));
+
+    useCase.execute('p1', task).subscribe((result) => {
+      expect(result).toEqual({ success: false, error: { code: 'NETWORK_ERROR' } });
+    });
   });
 });

--- a/src/app/features/projects/application/use-cases/tasks/update-task/update-task.use-case.ts
+++ b/src/app/features/projects/application/use-cases/tasks/update-task/update-task.use-case.ts
@@ -1,14 +1,27 @@
 import { Injectable, inject } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 
 import { Task } from '@features/projects/domain/entities/task.entity';
 import { TaskRepository } from '@features/projects/domain/repositories/task.repository';
+import { Result, fail, ok } from '@shared/utils/result';
+import { ProjectsError } from '@features/projects/application/errors/projects.error';
+import { TaskName } from '@features/projects/domain/value-objects/task-name.value-object';
 
 @Injectable()
 export class UpdateTaskUseCase {
   private readonly taskRepository = inject(TaskRepository);
 
-  execute(projectId: string, task: Task): Observable<Task> {
-    return this.taskRepository.update(projectId, task);
+  execute(projectId: string, task: Task): Observable<Result<Task, ProjectsError>> {
+    const taskNameResult = TaskName.tryCreate(task.name);
+    if (!taskNameResult.success) {
+      return of(fail(taskNameResult.error));
+    }
+
+    const normalizedTask = task.updateName(taskNameResult.value.value);
+    return this.taskRepository.update(projectId, normalizedTask).pipe(
+      map((updated): Result<Task, ProjectsError> => ok(updated)),
+      catchError(() => of(fail<ProjectsError>({ code: 'NETWORK_ERROR' }))),
+    );
   }
 }

--- a/src/app/features/projects/domain/entities/project.entity.spec.ts
+++ b/src/app/features/projects/domain/entities/project.entity.spec.ts
@@ -2,11 +2,20 @@ import { describe, it, expect } from 'vitest';
 import { Project } from './project.entity';
 import { ProjectName } from '@features/projects/domain/value-objects/project-name.value-object';
 
+function validProjectName(value: string): ProjectName {
+  const result = ProjectName.tryCreate(value);
+  if (!result.success) {
+    throw new Error('Invalid test project name');
+  }
+
+  return result.value;
+}
+
 describe('Project', () => {
-  const base = new Project('p1', ProjectName.create('Alpha'), false, ['s1', 's2']);
+  const base = new Project('p1', validProjectName('Alpha'), false, ['s1', 's2']);
 
   it('create uses random id when omitted', () => {
-    const p = Project.create(ProjectName.create('Xy'), true);
+    const p = Project.create(validProjectName('Xy'), true);
     expect(p.id.length).toBeGreaterThan(0);
     expect(p.name.value).toBe('Xy');
     expect(p.favorite).toBe(true);
@@ -14,7 +23,7 @@ describe('Project', () => {
   });
 
   it('create accepts explicit id for optimistic UI', () => {
-    const p = Project.create(ProjectName.create('Ab'), false, 'temp-1');
+    const p = Project.create(validProjectName('Ab'), false, 'temp-1');
     expect(p.id).toBe('temp-1');
   });
 
@@ -30,7 +39,7 @@ describe('Project', () => {
   });
 
   it('updateName returns new instance with same id', () => {
-    const next = base.updateName(ProjectName.create('Beta'));
+    const next = base.updateName(validProjectName('Beta'));
     expect(next.id).toBe('p1');
     expect(next.name.value).toBe('Beta');
     expect(base.name.value).toBe('Alpha');

--- a/src/app/features/projects/domain/entities/section.entity.ts
+++ b/src/app/features/projects/domain/entities/section.entity.ts
@@ -1,5 +1,3 @@
-import { SectionName } from '@features/projects/domain/value-objects/section-name.value-object';
-
 export class Section {
   constructor(
     public readonly id: string,
@@ -9,10 +7,9 @@ export class Section {
   ) {}
 
   static create(name: string, projectId: string, id?: string): Section {
-    const sectionName = SectionName.create(name);
     return new Section(
       id || crypto.randomUUID(),
-      sectionName.value,
+      name.trim(),
       projectId,
       []
     );
@@ -41,10 +38,9 @@ export class Section {
   }
 
   updateName(name: string): Section {
-    const sectionName = SectionName.create(name);
     return new Section(
       this.id,
-      sectionName.value,
+      name.trim(),
       this.projectId,
       this.taskIds
     );

--- a/src/app/features/projects/domain/entities/section.entity.ts
+++ b/src/app/features/projects/domain/entities/section.entity.ts
@@ -1,15 +1,26 @@
+import { SectionName } from '@features/projects/domain/value-objects/section-name.value-object';
+
 export class Section {
+  public readonly name: string;
+
   constructor(
     public readonly id: string,
-    public readonly name: string,
+    name: string,
     public readonly projectId: string,
     public readonly taskIds: readonly string[]
-  ) {}
+  ) {
+    const nameResult = SectionName.tryCreate(name);
+    if (!nameResult.success) {
+      throw new Error(Section.toMessage(nameResult.error.code));
+    }
+
+    this.name = nameResult.value.value;
+  }
 
   static create(name: string, projectId: string, id?: string): Section {
     return new Section(
       id || crypto.randomUUID(),
-      name.trim(),
+      name,
       projectId,
       []
     );
@@ -40,9 +51,22 @@ export class Section {
   updateName(name: string): Section {
     return new Section(
       this.id,
-      name.trim(),
+      name,
       this.projectId,
       this.taskIds
     );
+  }
+
+  private static toMessage(code: string): string {
+    switch (code) {
+      case 'SECTION_NAME_REQUIRED':
+        return 'Section name is required';
+      case 'SECTION_NAME_TOO_SHORT':
+        return 'Section name must be at least 2 characters';
+      case 'SECTION_NAME_TOO_LONG':
+        return 'Section name must be at most 50 characters';
+      default:
+        return 'Invalid section name';
+    }
   }
 }

--- a/src/app/features/projects/domain/value-objects/project-name.value-object.spec.ts
+++ b/src/app/features/projects/domain/value-objects/project-name.value-object.spec.ts
@@ -3,19 +3,32 @@ import { describe, it, expect } from 'vitest';
 import { ProjectName } from './project-name.value-object';
 
 describe('ProjectName', () => {
-  it('create trims whitespace', () => {
-    expect(ProjectName.create('  ab  ').value).toBe('ab');
+  it('tryCreate trims whitespace', () => {
+    const result = ProjectName.tryCreate('  ab  ');
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      throw new Error('Expected success result');
+    }
+
+    expect(result.value.value).toBe('ab');
   });
 
-  it('rejects blank', () => {
-    expect(() => ProjectName.create('   ')).toThrow('Project name is required');
+  it('tryCreate rejects blank with code', () => {
+    const result = ProjectName.tryCreate('   ');
+    expect(result).toEqual({ success: false, error: { code: 'PROJECT_NAME_REQUIRED' } });
   });
 
-  it('rejects too short', () => {
-    expect(() => ProjectName.create('a')).toThrow('at least 2 characters');
+  it('tryCreate rejects too short with code and min', () => {
+    const result = ProjectName.tryCreate('a');
+    expect(result).toEqual({ success: false, error: { code: 'PROJECT_NAME_TOO_SHORT', min: 2 } });
   });
 
-  it('rejects too long', () => {
-    expect(() => ProjectName.create('x'.repeat(51))).toThrow('at most 50 characters');
+  it('tryCreate rejects too long with code and max', () => {
+    const result = ProjectName.tryCreate('x'.repeat(51));
+    expect(result).toEqual({ success: false, error: { code: 'PROJECT_NAME_TOO_LONG', max: 50 } });
+  });
+
+  it('create keeps legacy throw behavior for compatibility', () => {
+    expect(() => ProjectName.create('')).toThrow('Project name is required');
   });
 });

--- a/src/app/features/projects/domain/value-objects/project-name.value-object.spec.ts
+++ b/src/app/features/projects/domain/value-objects/project-name.value-object.spec.ts
@@ -27,8 +27,4 @@ describe('ProjectName', () => {
     const result = ProjectName.tryCreate('x'.repeat(51));
     expect(result).toEqual({ success: false, error: { code: 'PROJECT_NAME_TOO_LONG', max: 50 } });
   });
-
-  it('create keeps legacy throw behavior for compatibility', () => {
-    expect(() => ProjectName.create('')).toThrow('Project name is required');
-  });
 });

--- a/src/app/features/projects/domain/value-objects/project-name.value-object.ts
+++ b/src/app/features/projects/domain/value-objects/project-name.value-object.ts
@@ -4,15 +4,6 @@ import { Result, fail, ok } from '@shared/utils/result';
 export class ProjectName {
   private constructor(public readonly value: string) {}
 
-  static create(raw: string): ProjectName {
-    const result = ProjectName.tryCreate(raw);
-    if (!result.success) {
-      throw new Error(ProjectName.toMessage(result.error));
-    }
-
-    return result.value;
-  }
-
   static tryCreate(raw: string): Result<ProjectName, ProjectsError> {
     const value = raw.trim();
 
@@ -27,18 +18,5 @@ export class ProjectName {
     }
 
     return ok(new ProjectName(value));
-  }
-
-  private static toMessage(error: ProjectsError): string {
-    switch (error.code) {
-      case 'PROJECT_NAME_REQUIRED':
-        return 'Project name is required';
-      case 'PROJECT_NAME_TOO_SHORT':
-        return 'Project name must be at least 2 characters';
-      case 'PROJECT_NAME_TOO_LONG':
-        return 'Project name must be at most 50 characters';
-      default:
-        return 'Invalid project name';
-    }
   }
 }

--- a/src/app/features/projects/domain/value-objects/project-name.value-object.ts
+++ b/src/app/features/projects/domain/value-objects/project-name.value-object.ts
@@ -1,19 +1,44 @@
+import { ProjectsError } from '@features/projects/application/errors/projects.error';
+import { Result, fail, ok } from '@shared/utils/result';
+
 export class ProjectName {
   private constructor(public readonly value: string) {}
 
   static create(raw: string): ProjectName {
+    const result = ProjectName.tryCreate(raw);
+    if (!result.success) {
+      throw new Error(ProjectName.toMessage(result.error));
+    }
+
+    return result.value;
+  }
+
+  static tryCreate(raw: string): Result<ProjectName, ProjectsError> {
     const value = raw.trim();
 
     if (!value) {
-      throw new Error('Project name is required');
+      return fail({ code: 'PROJECT_NAME_REQUIRED' });
     }
     if (value.length < 2) {
-      throw new Error('Project name must be at least 2 characters');
+      return fail({ code: 'PROJECT_NAME_TOO_SHORT', min: 2 });
     }
     if (value.length > 50) {
-      throw new Error('Project name must be at most 50 characters');
+      return fail({ code: 'PROJECT_NAME_TOO_LONG', max: 50 });
     }
 
-    return new ProjectName(value);
+    return ok(new ProjectName(value));
+  }
+
+  private static toMessage(error: ProjectsError): string {
+    switch (error.code) {
+      case 'PROJECT_NAME_REQUIRED':
+        return 'Project name is required';
+      case 'PROJECT_NAME_TOO_SHORT':
+        return 'Project name must be at least 2 characters';
+      case 'PROJECT_NAME_TOO_LONG':
+        return 'Project name must be at most 50 characters';
+      default:
+        return 'Invalid project name';
+    }
   }
 }

--- a/src/app/features/projects/domain/value-objects/section-name.value-object.spec.ts
+++ b/src/app/features/projects/domain/value-objects/section-name.value-object.spec.ts
@@ -27,8 +27,4 @@ describe('SectionName', () => {
     const result = SectionName.tryCreate('x'.repeat(51));
     expect(result).toEqual({ success: false, error: { code: 'SECTION_NAME_TOO_LONG', max: 50 } });
   });
-
-  it('create keeps legacy throw behavior for compatibility', () => {
-    expect(() => SectionName.create('')).toThrow('Section name is required');
-  });
 });

--- a/src/app/features/projects/domain/value-objects/section-name.value-object.spec.ts
+++ b/src/app/features/projects/domain/value-objects/section-name.value-object.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { SectionName } from './section-name.value-object';
+
+describe('SectionName', () => {
+  it('tryCreate trims whitespace', () => {
+    const result = SectionName.tryCreate('  Backlog  ');
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      throw new Error('Expected success result');
+    }
+
+    expect(result.value.value).toBe('Backlog');
+  });
+
+  it('tryCreate rejects blank with code', () => {
+    const result = SectionName.tryCreate('   ');
+    expect(result).toEqual({ success: false, error: { code: 'SECTION_NAME_REQUIRED' } });
+  });
+
+  it('tryCreate rejects too short with code and min', () => {
+    const result = SectionName.tryCreate('x');
+    expect(result).toEqual({ success: false, error: { code: 'SECTION_NAME_TOO_SHORT', min: 2 } });
+  });
+
+  it('tryCreate rejects too long with code and max', () => {
+    const result = SectionName.tryCreate('x'.repeat(51));
+    expect(result).toEqual({ success: false, error: { code: 'SECTION_NAME_TOO_LONG', max: 50 } });
+  });
+
+  it('create keeps legacy throw behavior for compatibility', () => {
+    expect(() => SectionName.create('')).toThrow('Section name is required');
+  });
+});

--- a/src/app/features/projects/domain/value-objects/section-name.value-object.ts
+++ b/src/app/features/projects/domain/value-objects/section-name.value-object.ts
@@ -1,19 +1,44 @@
+import { ProjectsError } from '@features/projects/application/errors/projects.error';
+import { Result, fail, ok } from '@shared/utils/result';
+
 export class SectionName {
   private constructor(public readonly value: string) {}
 
   static create(raw: string): SectionName {
+    const result = SectionName.tryCreate(raw);
+    if (!result.success) {
+      throw new Error(SectionName.toMessage(result.error));
+    }
+
+    return result.value;
+  }
+
+  static tryCreate(raw: string): Result<SectionName, ProjectsError> {
     const value = raw.trim();
 
     if (!value) {
-      throw new Error('Section name is required');
+      return fail({ code: 'SECTION_NAME_REQUIRED' });
     }
     if (value.length < 2) {
-      throw new Error('Section name must be at least 2 characters');
+      return fail({ code: 'SECTION_NAME_TOO_SHORT', min: 2 });
     }
     if (value.length > 50) {
-      throw new Error('Section name must be at most 50 characters');
+      return fail({ code: 'SECTION_NAME_TOO_LONG', max: 50 });
     }
 
-    return new SectionName(value);
+    return ok(new SectionName(value));
+  }
+
+  private static toMessage(error: ProjectsError): string {
+    switch (error.code) {
+      case 'SECTION_NAME_REQUIRED':
+        return 'Section name is required';
+      case 'SECTION_NAME_TOO_SHORT':
+        return 'Section name must be at least 2 characters';
+      case 'SECTION_NAME_TOO_LONG':
+        return 'Section name must be at most 50 characters';
+      default:
+        return 'Invalid section name';
+    }
   }
 }

--- a/src/app/features/projects/domain/value-objects/task-name.value-object.spec.ts
+++ b/src/app/features/projects/domain/value-objects/task-name.value-object.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { TaskName } from './task-name.value-object';
+
+describe('TaskName', () => {
+  it('tryCreate trims whitespace', () => {
+    const result = TaskName.tryCreate('  Prepare release  ');
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      throw new Error('Expected success result');
+    }
+
+    expect(result.value.value).toBe('Prepare release');
+  });
+
+  it('tryCreate rejects blank with code', () => {
+    const result = TaskName.tryCreate('   ');
+    expect(result).toEqual({ success: false, error: { code: 'TASK_NAME_REQUIRED' } });
+  });
+
+  it('tryCreate rejects too short with code and min', () => {
+    const result = TaskName.tryCreate('x');
+    expect(result).toEqual({ success: false, error: { code: 'TASK_NAME_TOO_SHORT', min: 2 } });
+  });
+
+  it('tryCreate rejects too long with code and max', () => {
+    const result = TaskName.tryCreate('x'.repeat(51));
+    expect(result).toEqual({ success: false, error: { code: 'TASK_NAME_TOO_LONG', max: 50 } });
+  });
+});

--- a/src/app/features/projects/domain/value-objects/task-name.value-object.ts
+++ b/src/app/features/projects/domain/value-objects/task-name.value-object.ts
@@ -1,22 +1,22 @@
 import { ProjectsError } from '@features/projects/application/errors/projects.error';
 import { Result, fail, ok } from '@shared/utils/result';
 
-export class SectionName {
+export class TaskName {
   private constructor(public readonly value: string) {}
 
-  static tryCreate(raw: string): Result<SectionName, ProjectsError> {
+  static tryCreate(raw: string): Result<TaskName, ProjectsError> {
     const value = raw.trim();
 
     if (!value) {
-      return fail({ code: 'SECTION_NAME_REQUIRED' });
+      return fail({ code: 'TASK_NAME_REQUIRED' });
     }
     if (value.length < 2) {
-      return fail({ code: 'SECTION_NAME_TOO_SHORT', min: 2 });
+      return fail({ code: 'TASK_NAME_TOO_SHORT', min: 2 });
     }
     if (value.length > 50) {
-      return fail({ code: 'SECTION_NAME_TOO_LONG', max: 50 });
+      return fail({ code: 'TASK_NAME_TOO_LONG', max: 50 });
     }
 
-    return ok(new SectionName(value));
+    return ok(new TaskName(value));
   }
 }

--- a/src/app/features/projects/infrastructure/mappers/project.mapper.spec.ts
+++ b/src/app/features/projects/infrastructure/mappers/project.mapper.spec.ts
@@ -6,6 +6,15 @@ import { ProjectSummaryDto } from '@features/projects/infrastructure/dto/respons
 import { Project } from '@features/projects/domain/entities/project.entity';
 import { ProjectName } from '@features/projects/domain/value-objects/project-name.value-object';
 
+function validProjectName(value: string): ProjectName {
+  const result = ProjectName.tryCreate(value);
+  if (!result.success) {
+    throw new Error('Invalid test project name');
+  }
+
+  return result.value;
+}
+
 describe('ProjectMapper', () => {
   const fullDto: ProjectResponseDto = {
     id: '10',
@@ -57,7 +66,7 @@ describe('ProjectMapper', () => {
   });
 
   it('toDto maps name and favorite', () => {
-    const p = new Project('1', ProjectName.create('NN'), true, []);
+    const p = new Project('1', validProjectName('NN'), true, []);
     expect(ProjectMapper.toDto(p)).toEqual({ name: 'NN', favorite: true });
   });
 });

--- a/src/app/features/projects/infrastructure/mappers/project.mapper.ts
+++ b/src/app/features/projects/infrastructure/mappers/project.mapper.ts
@@ -10,11 +10,25 @@ import { SectionMapper } from '@features/projects/infrastructure/mappers/section
 import { TaskMapper } from '@features/projects/infrastructure/mappers/task.mapper';
 
 export class ProjectMapper {
+  private static toProjectName(rawName: string): ProjectName {
+    const result = ProjectName.tryCreate(rawName);
+    if (result.success) {
+      return result.value;
+    }
+
+    const fallback = ProjectName.tryCreate('Untitled');
+    if (fallback.success) {
+      return fallback.value;
+    }
+
+    throw new Error('Failed to map project name');
+  }
+
   static toDomain(dto: ProjectResponseDto): Project {
     const sectionIds = (dto.sections ?? []).map(s => String(s.id));
     return new Project(
       String(dto.id),
-      ProjectName.create(dto.name),
+      ProjectMapper.toProjectName(dto.name),
       dto.favorite,
       sectionIds
     );
@@ -46,7 +60,7 @@ export class ProjectMapper {
   static toSummary(dto: ProjectSummaryDto): ProjectSummary {
     const project = new Project(
       String(dto.id),
-      ProjectName.create(dto.name),
+      ProjectMapper.toProjectName(dto.name),
       dto.favorite,
       []
     );

--- a/src/app/features/projects/infrastructure/repositories/http-project.repository.spec.ts
+++ b/src/app/features/projects/infrastructure/repositories/http-project.repository.spec.ts
@@ -10,6 +10,15 @@ import { ProjectSummaryDto } from '@features/projects/infrastructure/dto/respons
 import { Project } from '@features/projects/domain/entities/project.entity';
 import { ProjectName } from '@features/projects/domain/value-objects/project-name.value-object';
 
+function validProjectName(value: string): ProjectName {
+  const result = ProjectName.tryCreate(value);
+  if (!result.success) {
+    throw new Error('Invalid test project name');
+  }
+
+  return result.value;
+}
+
 describe('HttpProjectRepository', () => {
   let repository: HttpProjectRepository;
   let httpMock: HttpTestingController;
@@ -27,7 +36,7 @@ describe('HttpProjectRepository', () => {
   });
 
   it('create posts ProjectMapper body and maps response', () => {
-    const project = Project.create(ProjectName.create('NN'), false);
+    const project = Project.create(validProjectName('NN'), false);
     const response: ProjectResponseDto = { id: '1', name: 'NN', favorite: false, sections: [] };
     let result: unknown;
     repository.create(project).subscribe((p) => (result = p));

--- a/src/app/features/projects/infrastructure/repositories/http-section.repository.spec.ts
+++ b/src/app/features/projects/infrastructure/repositories/http-section.repository.spec.ts
@@ -45,6 +45,6 @@ describe('HttpSectionRepository', () => {
     repository.findById('p1', 's1').subscribe();
     const req = httpMock.expectOne('/projects/p1/section/s1/get');
     expect(req.request.method).toBe('GET');
-    req.flush({ id: 1, name: 'S', tasks: [] });
+    req.flush({ id: 1, name: 'Sec', tasks: [] });
   });
 });

--- a/src/app/features/projects/presentation/mappers/projects-ui-error.mapper.ts
+++ b/src/app/features/projects/presentation/mappers/projects-ui-error.mapper.ts
@@ -1,12 +1,5 @@
 import { ProjectsError } from '@features/projects/application/errors/projects.error';
-
-export interface UiError {
-  code: string;
-  kind: 'validation' | 'network' | 'unexpected';
-  message: string;
-  fieldErrors?: Record<string, string>;
-  retryable?: boolean;
-}
+import { UiError } from '@features/projects/presentation/models/ui-error';
 
 export function toProjectsUiError(error: ProjectsError): UiError {
   switch (error.code) {
@@ -56,6 +49,30 @@ export function toProjectsUiError(error: ProjectsError): UiError {
         kind: 'validation',
         message: 'Section name is too long',
         fieldErrors: { sectionName: `Maximum ${String(error.max)} characters` },
+        retryable: false,
+      };
+    case 'TASK_NAME_REQUIRED':
+      return {
+        code: error.code,
+        kind: 'validation',
+        message: 'Task name is required',
+        fieldErrors: { taskName: 'Task name is required' },
+        retryable: false,
+      };
+    case 'TASK_NAME_TOO_SHORT':
+      return {
+        code: error.code,
+        kind: 'validation',
+        message: 'Task name is too short',
+        fieldErrors: { taskName: `Minimum ${String(error.min)} characters` },
+        retryable: false,
+      };
+    case 'TASK_NAME_TOO_LONG':
+      return {
+        code: error.code,
+        kind: 'validation',
+        message: 'Task name is too long',
+        fieldErrors: { taskName: `Maximum ${String(error.max)} characters` },
         retryable: false,
       };
     case 'NETWORK_ERROR':

--- a/src/app/features/projects/presentation/mappers/projects-ui-error.mapper.ts
+++ b/src/app/features/projects/presentation/mappers/projects-ui-error.mapper.ts
@@ -1,0 +1,76 @@
+import { ProjectsError } from '@features/projects/application/errors/projects.error';
+
+export interface UiError {
+  code: string;
+  kind: 'validation' | 'network' | 'unexpected';
+  message: string;
+  fieldErrors?: Record<string, string>;
+  retryable?: boolean;
+}
+
+export function toProjectsUiError(error: ProjectsError): UiError {
+  switch (error.code) {
+    case 'PROJECT_NAME_REQUIRED':
+      return {
+        code: error.code,
+        kind: 'validation',
+        message: 'Project name is required',
+        fieldErrors: { projectName: 'Project name is required' },
+        retryable: false,
+      };
+    case 'PROJECT_NAME_TOO_SHORT':
+      return {
+        code: error.code,
+        kind: 'validation',
+        message: 'Project name is too short',
+        fieldErrors: { projectName: `Minimum ${String(error.min)} characters` },
+        retryable: false,
+      };
+    case 'PROJECT_NAME_TOO_LONG':
+      return {
+        code: error.code,
+        kind: 'validation',
+        message: 'Project name is too long',
+        fieldErrors: { projectName: `Maximum ${String(error.max)} characters` },
+        retryable: false,
+      };
+    case 'SECTION_NAME_REQUIRED':
+      return {
+        code: error.code,
+        kind: 'validation',
+        message: 'Section name is required',
+        fieldErrors: { sectionName: 'Section name is required' },
+        retryable: false,
+      };
+    case 'SECTION_NAME_TOO_SHORT':
+      return {
+        code: error.code,
+        kind: 'validation',
+        message: 'Section name is too short',
+        fieldErrors: { sectionName: `Minimum ${String(error.min)} characters` },
+        retryable: false,
+      };
+    case 'SECTION_NAME_TOO_LONG':
+      return {
+        code: error.code,
+        kind: 'validation',
+        message: 'Section name is too long',
+        fieldErrors: { sectionName: `Maximum ${String(error.max)} characters` },
+        retryable: false,
+      };
+    case 'NETWORK_ERROR':
+      return {
+        code: error.code,
+        kind: 'network',
+        message: 'Network error. Please try again.',
+        retryable: true,
+      };
+    case 'UNEXPECTED_ERROR':
+      return {
+        code: error.code,
+        kind: 'unexpected',
+        message: 'Unexpected error. Please try again.',
+        retryable: true,
+      };
+  }
+}

--- a/src/app/features/projects/presentation/models/project-state.ts
+++ b/src/app/features/projects/presentation/models/project-state.ts
@@ -1,4 +1,5 @@
 import { ProjectOutput } from '@features/projects/application/dtos/project-output';
+import { UiError } from '@features/projects/presentation/models/ui-error';
 
 /**
  * Normalized state for all projects, keyed by ID.
@@ -20,6 +21,8 @@ export interface ProjectState {
   loading: boolean;
   /** Last error message, if any */
   error: string | null;
+  /** Rich error details for UI rendering (field messages, retryability, kind). */
+  errorDetails: UiError | null;
 }
 
 /** Convenience factory for producing the initial (empty) state */
@@ -28,5 +31,6 @@ export const initialProjectState: ProjectState = {
   selectedProjectId: null,
   loading: false,
   error: null,
+  errorDetails: null,
 };
 

--- a/src/app/features/projects/presentation/models/section-state.ts
+++ b/src/app/features/projects/presentation/models/section-state.ts
@@ -1,4 +1,5 @@
 import { Section } from '@features/projects/domain/entities/section.entity';
+import { UiError } from '@features/projects/presentation/models/ui-error';
 
 /**
  * Normalized state for all sections, keyed by ID.
@@ -9,10 +10,12 @@ export interface SectionState {
   sections: Record<string, Section>;
   loading: boolean;
   error: string | null;
+  errorDetails: UiError | null;
 }
 
 export const initialSectionState: SectionState = {
   sections: {},
   loading: false,
   error: null,
+  errorDetails: null,
 };

--- a/src/app/features/projects/presentation/models/task-state.ts
+++ b/src/app/features/projects/presentation/models/task-state.ts
@@ -1,4 +1,5 @@
 import { Task } from '@features/projects/domain/entities/task.entity';
+import { UiError } from '@features/projects/presentation/models/ui-error';
 
 /**
  * Normalized state for all tasks, keyed by ID.
@@ -10,10 +11,12 @@ export interface TaskState {
   tasks: Record<string, Task>;
   loading: boolean;
   error: string | null;
+  errorDetails: UiError | null;
 }
 
 export const initialTaskState: TaskState = {
   tasks: {},
   loading: false,
   error: null,
+  errorDetails: null,
 };

--- a/src/app/features/projects/presentation/models/ui-error.ts
+++ b/src/app/features/projects/presentation/models/ui-error.ts
@@ -1,0 +1,7 @@
+export interface UiError {
+  code: string;
+  kind: 'validation' | 'network' | 'unexpected';
+  message: string;
+  fieldErrors?: Record<string, string>;
+  retryable?: boolean;
+}

--- a/src/app/features/projects/presentation/store/project-summary.store.spec.ts
+++ b/src/app/features/projects/presentation/store/project-summary.store.spec.ts
@@ -47,7 +47,7 @@ describe('ProjectSummaryStore', () => {
   it('pendingCountFor computes from section/task stores when not cached', () => {
     const start = new Date();
     sectionsState.set({
-      s1: new Section('s1', 'S', 'p1', ['t1', 't2']),
+      s1: new Section('s1', 'Sec', 'p1', ['t1', 't2']),
     });
     tasksState.set({
       t1: new Task('t1', 's1', 'Open', false, start, undefined, undefined, undefined, undefined, undefined, []),

--- a/src/app/features/projects/presentation/store/project.store.spec.ts
+++ b/src/app/features/projects/presentation/store/project.store.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { beforeEach, describe, it, expect, vi } from 'vitest';
-import { Observable, of, throwError } from 'rxjs';
+import { Observable, of } from 'rxjs';
 
 import { ProjectStore } from './project.store';
 import { LoadProjectUseCase } from '@features/projects/application/use-cases/projects/load-project/load-project.use-case';
@@ -44,7 +44,9 @@ describe('ProjectStore', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     loadAllExecute.mockReturnValue(of([]));
-    createProjectExecute.mockReturnValue(of({ id: 'new-id', name: 'New', favorite: false, sectionIds: [] }));
+    createProjectExecute.mockReturnValue(
+      of({ success: true, value: { id: 'new-id', name: 'New', favorite: false, sectionIds: [] } }),
+    );
     deleteProjectExecute.mockReturnValue(of(void 0));
     loadProjectExecute.mockReturnValue(
       of({
@@ -139,10 +141,10 @@ describe('ProjectStore', () => {
 
   it('createProject rolls back optimistic entry on error', () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
-    createProjectExecute.mockReturnValue(throwError(() => new Error('boom')));
+    createProjectExecute.mockReturnValue(of({ success: false, error: { code: 'NETWORK_ERROR' } }));
     store.createProject({ name: 'New', favorite: false });
     expect(store.projects().some((p) => p.id.startsWith('temp-'))).toBe(false);
-    expect(store.error()).toBe('boom');
+    expect(store.error()).toBe('Network error. Please try again.');
     errorSpy.mockRestore();
   });
 

--- a/src/app/features/projects/presentation/store/project.store.ts
+++ b/src/app/features/projects/presentation/store/project.store.ts
@@ -28,6 +28,7 @@ import { SectionDto } from '@features/projects/infrastructure/dto/section.dto';
 import { TaskDto } from '@features/projects/infrastructure/dto/task.dto';
 import { ProjectsError } from '@features/projects/application/errors/projects.error';
 import { toProjectsUiError } from '@features/projects/presentation/mappers/projects-ui-error.mapper';
+import { UiError } from '@features/projects/presentation/models/ui-error';
 
 /**
  * Store for **projects** only.
@@ -84,6 +85,9 @@ export class ProjectStore {
 
   /** Last error */
   readonly error = computed(() => this.state().error);
+
+  /** Last rich error details */
+  readonly errorDetails = computed(() => this.state().errorDetails);
 
   // ===================================================================
   // SELECTORS — denormalized view-model for the UI
@@ -143,6 +147,7 @@ export class ProjectStore {
       ...s,
       loading: true,
       error: null,
+      errorDetails: null,
     }));
   }
 
@@ -164,14 +169,14 @@ export class ProjectStore {
   }
 
   /** Record an error in the store and log it to the console. */
-  private setError(message: string, context: string, error: unknown): void {
-    this.state.update(s => ({ ...s, error: message }));
+  private setError(message: string, context: string, error: unknown, details: UiError | null = null): void {
+    this.state.update(s => ({ ...s, error: message, errorDetails: details }));
     console.error(`Failed to ${context}:`, error);
   }
 
   private setResultError(error: ProjectsError, context: string): void {
     const uiError = toProjectsUiError(error);
-    this.setError(uiError.message, context, error);
+    this.setError(uiError.message, context, error, uiError);
   }
 
   /**

--- a/src/app/features/projects/presentation/store/project.store.ts
+++ b/src/app/features/projects/presentation/store/project.store.ts
@@ -26,6 +26,8 @@ import { SectionMapper } from '@features/projects/infrastructure/mappers/section
 import { TaskMapper } from '@features/projects/infrastructure/mappers/task.mapper';
 import { SectionDto } from '@features/projects/infrastructure/dto/section.dto';
 import { TaskDto } from '@features/projects/infrastructure/dto/task.dto';
+import { ProjectsError } from '@features/projects/application/errors/projects.error';
+import { toProjectsUiError } from '@features/projects/presentation/mappers/projects-ui-error.mapper';
 
 /**
  * Store for **projects** only.
@@ -167,6 +169,11 @@ export class ProjectStore {
     console.error(`Failed to ${context}:`, error);
   }
 
+  private setResultError(error: ProjectsError, context: string): void {
+    const uiError = toProjectsUiError(error);
+    this.setError(uiError.message, context, error);
+  }
+
   /**
    * Create a new project with **optimistic UI**.
    *
@@ -190,18 +197,21 @@ export class ProjectStore {
 
     // Fire the backend request in parallel
     this.createProjectUseCase.execute(input).subscribe({
-      next: (project) => {
+      next: (result) => {
+        if (!result.success) {
+          // Revert the optimistic update
+          this.removeProject(tempId);
+          this.projectSummaryStore.removePendingCount(tempId);
+          this.setResultError(result.error, 'create project');
+          return;
+        }
+
+        const project = result.value;
         // Replace the temp project with the real one from the backend
         this.removeProject(tempId);
         this.upsertProject(project.id, project);
         this.projectSummaryStore.removePendingCount(tempId);
         this.projectSummaryStore.mergePendingCounts({ [project.id]: 0 });
-      },
-      error: (error) => {
-        // Revert the optimistic update
-        this.removeProject(tempId);
-        this.projectSummaryStore.removePendingCount(tempId);
-        this.setError(error.message, 'create project', error);
       },
     });
   }
@@ -225,12 +235,15 @@ export class ProjectStore {
     this.upsertProject(input.id, optimistic);
 
     this.updateProjectUseCase.execute(input).subscribe({
-      next: (updated) => {
+      next: (result) => {
+        if (!result.success) {
+          this.upsertProject(input.id, existing);
+          this.setResultError(result.error, 'update project');
+          return;
+        }
+
+        const updated = result.value;
         this.upsertProject(updated.id, { ...existing, name: updated.name, favorite: input.favorite });
-      },
-      error: (error) => {
-        this.upsertProject(input.id, existing);
-        this.setError(error.message, 'update project', error);
       },
     });
   }
@@ -612,7 +625,7 @@ export class ProjectStore {
         this.sectionStore.removeSection(sectionId);
 
         const existing = this.state().projects[projectId];
-        if (existing && existing.sectionIds.includes(sectionId)) {
+        if (existing?.sectionIds.includes(sectionId)) {
           this.upsertProject(projectId, {
             ...existing,
             sectionIds: existing.sectionIds.filter((sId) => sId !== sectionId),
@@ -623,7 +636,10 @@ export class ProjectStore {
 
       case 'task_created': {
         const dto = event.data as TaskDto;
-        const sectionId = String((event.data as Record<string, unknown>)['sectionId'] ?? dto.id);
+        const rawSectionId = (event.data as Record<string, unknown>)['sectionId'];
+        const sectionId = typeof rawSectionId === 'string' || typeof rawSectionId === 'number'
+          ? String(rawSectionId)
+          : String(dto.id);
         const taskId = String(dto.id);
         const tasks = TaskMapper.flattenToDomain(dto, sectionId);
         this.taskStore.mergeTasks(tasks);

--- a/src/app/features/projects/presentation/store/section.store.spec.ts
+++ b/src/app/features/projects/presentation/store/section.store.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection, signal } from '@angular/core';
 import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { of } from 'rxjs';
 
 import { SectionStore } from './section.store';
 import { CreateSectionUseCase } from '@features/projects/application/use-cases/sections/create-section/create-section.use-case';
@@ -11,15 +12,21 @@ import { Section } from '@features/projects/domain/entities/section.entity';
 
 describe('SectionStore', () => {
   let store: SectionStore;
+  const createSectionExecute = vi.fn();
+  const updateSectionExecute = vi.fn();
+  const deleteSectionExecute = vi.fn();
 
   beforeEach(() => {
+    vi.clearAllMocks();
+    createSectionExecute.mockReturnValue(of({ success: true, value: new Section('s1', 'Backlog', 'p1', []) }));
+
     TestBed.configureTestingModule({
       providers: [
         provideZonelessChangeDetection(),
         SectionStore,
-        { provide: CreateSectionUseCase, useValue: { execute: vi.fn() } },
-        { provide: UpdateSectionUseCase, useValue: { execute: vi.fn() } },
-        { provide: DeleteSectionUseCase, useValue: { execute: vi.fn() } },
+        { provide: CreateSectionUseCase, useValue: { execute: createSectionExecute } },
+        { provide: UpdateSectionUseCase, useValue: { execute: updateSectionExecute } },
+        { provide: DeleteSectionUseCase, useValue: { execute: deleteSectionExecute } },
         {
           provide: TaskStore,
           useValue: { tasks: signal<Record<string, unknown>>({}).asReadonly() },
@@ -35,5 +42,22 @@ describe('SectionStore', () => {
     store.mergeSections([a, b]);
     expect(store.sections()['s1']?.name).toBe('Alpha');
     expect(store.sections()['s2']?.name).toBe('Beta');
+  });
+
+  it('createSection saves created section on success result', () => {
+    store.createSection('p1', 'Backlog');
+
+    expect(createSectionExecute).toHaveBeenCalledWith('p1', 'Backlog');
+    expect(store.sections()['s1']?.name).toBe('Backlog');
+  });
+
+  it('createSection stores mapped error message on failure result', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    createSectionExecute.mockReturnValue(of({ success: false, error: { code: 'SECTION_NAME_REQUIRED' } }));
+
+    store.createSection('p1', '');
+
+    expect(store.error()).toBe('Section name is required');
+    errorSpy.mockRestore();
   });
 });

--- a/src/app/features/projects/presentation/store/section.store.ts
+++ b/src/app/features/projects/presentation/store/section.store.ts
@@ -6,6 +6,7 @@ import { initialSectionState, SectionState } from '@features/projects/presentati
 import { Section } from '@features/projects/domain/entities/section.entity';
 import { TaskStore } from '@features/projects/presentation/store/task.store';
 import { toProjectsUiError } from '@features/projects/presentation/mappers/projects-ui-error.mapper';
+import { UiError } from '@features/projects/presentation/models/ui-error';
 
 /**
  * Normalized store for **sections**.
@@ -34,6 +35,14 @@ export class SectionStore {
 
   /** Last error */
   readonly error = computed(() => this.state().error);
+
+  /** Last rich error details */
+  readonly errorDetails = computed(() => this.state().errorDetails);
+
+  private setError(message: string, details: UiError | null, context: string, raw: unknown): void {
+    this.state.update(s => ({ ...s, error: message, errorDetails: details }));
+    console.error(`Failed to ${context}:`, raw);
+  }
 
   /** Get a single section by ID */
   getSection(sectionId: string): Section | undefined {
@@ -71,8 +80,8 @@ export class SectionStore {
     this.createSectionUseCase.execute(projectId, sectionName).subscribe({
       next: (result) => {
         if (!result.success) {
-          this.state.update(s => ({ ...s, error: toProjectsUiError(result.error).message }));
-          console.error('Failed to create section:', result.error);
+          const uiError = toProjectsUiError(result.error);
+          this.setError(uiError.message, uiError, 'create section', result.error);
           return;
         }
 
@@ -128,10 +137,12 @@ export class SectionStore {
     this.updateSectionUseCase.execute(input).subscribe({
       next: (result) => {
         if (!result.success) {
+          const uiError = toProjectsUiError(result.error);
           this.state.update(s => ({
             ...s,
             sections: { ...s.sections, [sectionId]: existing },
-            error: toProjectsUiError(result.error).message,
+            error: uiError.message,
+            errorDetails: uiError,
           }));
           console.error('Failed to update section:', result.error);
           return;
@@ -176,7 +187,7 @@ export class SectionStore {
           ...s,
           sections: { ...s.sections, [sectionId]: existing },
         }));
-        console.error('Failed to delete section:', error);
+        this.setError(error.message, null, 'delete section', error);
       },
     });
   }

--- a/src/app/features/projects/presentation/store/section.store.ts
+++ b/src/app/features/projects/presentation/store/section.store.ts
@@ -5,6 +5,7 @@ import { DeleteSectionUseCase } from '@features/projects/application/use-cases/s
 import { initialSectionState, SectionState } from '@features/projects/presentation/models/section-state';
 import { Section } from '@features/projects/domain/entities/section.entity';
 import { TaskStore } from '@features/projects/presentation/store/task.store';
+import { toProjectsUiError } from '@features/projects/presentation/mappers/projects-ui-error.mapper';
 
 /**
  * Normalized store for **sections**.
@@ -68,16 +69,19 @@ export class SectionStore {
     onCreated?: (section: Section) => void,
   ): void {
     this.createSectionUseCase.execute(projectId, sectionName).subscribe({
-      next: (section) => {
+      next: (result) => {
+        if (!result.success) {
+          this.state.update(s => ({ ...s, error: toProjectsUiError(result.error).message }));
+          console.error('Failed to create section:', result.error);
+          return;
+        }
+
+        const section = result.value;
         this.state.update(s => ({
           ...s,
           sections: { ...s.sections, [section.id]: section },
         }));
         onCreated?.(section);
-      },
-      error: (error) => {
-        this.state.update(s => ({ ...s, error: error.message }));
-        console.error('Failed to create section:', error);
       },
     });
   }
@@ -122,7 +126,18 @@ export class SectionStore {
     };
 
     this.updateSectionUseCase.execute(input).subscribe({
-      next: (updated) => {
+      next: (result) => {
+        if (!result.success) {
+          this.state.update(s => ({
+            ...s,
+            sections: { ...s.sections, [sectionId]: existing },
+            error: toProjectsUiError(result.error).message,
+          }));
+          console.error('Failed to update section:', result.error);
+          return;
+        }
+
+        const updated = result.value;
         this.state.update(s => ({
           ...s,
           sections: {
@@ -130,13 +145,6 @@ export class SectionStore {
             [sectionId]: new Section(updated.id, updated.name, updated.projectId, existing.taskIds),
           },
         }));
-      },
-      error: (error) => {
-        this.state.update(s => ({
-          ...s,
-          sections: { ...s.sections, [sectionId]: existing },
-        }));
-        console.error('Failed to update section:', error);
       },
     });
   }

--- a/src/app/features/projects/presentation/store/task.store.spec.ts
+++ b/src/app/features/projects/presentation/store/task.store.spec.ts
@@ -19,7 +19,7 @@ describe('TaskStore', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     toggleExecute.mockImplementation((t: Task) => of(t.complete()));
-    updateExecute.mockImplementation((_projectId: string, task: Task) => of(task));
+    updateExecute.mockImplementation((_projectId: string, task: Task) => of({ success: true, value: task }));
     deleteExecute.mockReturnValue(of(void 0));
 
     TestBed.configureTestingModule({

--- a/src/app/features/projects/presentation/store/task.store.ts
+++ b/src/app/features/projects/presentation/store/task.store.ts
@@ -5,6 +5,9 @@ import { UpdateTaskUseCase } from '@features/projects/application/use-cases/task
 import { DeleteTaskUseCase } from '@features/projects/application/use-cases/tasks/delete-task/delete-task.use-case';
 import { initialTaskState, TaskState } from '@features/projects/presentation/models/task-state';
 import { Task } from '@features/projects/domain/entities/task.entity';
+import { toProjectsUiError } from '@features/projects/presentation/mappers/projects-ui-error.mapper';
+import { ProjectsError } from '@features/projects/application/errors/projects.error';
+import { UiError } from '@features/projects/presentation/models/ui-error';
 
 /**
  * Normalized store for **tasks** (and subtasks).
@@ -34,6 +37,19 @@ export class TaskStore {
 
   /** Last error */
   readonly error = computed(() => this.state().error);
+
+  /** Last rich error details */
+  readonly errorDetails = computed(() => this.state().errorDetails);
+
+  private setError(message: string, details: UiError | null, context: string, raw: unknown): void {
+    this.state.update(s => ({ ...s, error: message, errorDetails: details }));
+    console.error(`Failed to ${context}:`, raw);
+  }
+
+  private setResultError(error: ProjectsError, context: string): void {
+    const uiError = toProjectsUiError(error);
+    this.setError(uiError.message, uiError, context, error);
+  }
 
   /** Get a single task by ID */
   getTask(taskId: string): Task | undefined {
@@ -75,16 +91,18 @@ export class TaskStore {
     onCreated?: (task: Task) => void,
   ): void {
     this.createTaskUseCase.execute(projectId, sectionId, taskName).subscribe({
-      next: (task) => {
+      next: (result) => {
+        if (!result.success) {
+          this.setResultError(result.error, 'create task');
+          return;
+        }
+
+        const task = result.value;
         this.state.update(s => ({
           ...s,
           tasks: { ...s.tasks, [task.id]: task },
         }));
         onCreated?.(task);
-      },
-      error: (error) => {
-        this.state.update(s => ({ ...s, error: error.message }));
-        console.error('Failed to create task:', error);
       },
     });
   }
@@ -103,7 +121,13 @@ export class TaskStore {
     }
 
     this.createTaskUseCase.execute(projectId, sectionId, taskName).subscribe({
-      next: (subtask) => {
+      next: (result) => {
+        if (!result.success) {
+          this.setResultError(result.error, 'create subtask');
+          return;
+        }
+
+        const subtask = result.value;
         // Override the subtask with the correct parentTaskId
         const subtaskWithParent = new Task(
           subtask.id,
@@ -126,10 +150,6 @@ export class TaskStore {
             [parentTaskId]: (s.tasks[parentTaskId]).addSubtask(subtaskWithParent.id),
           },
         }));
-      },
-      error: (error) => {
-        this.state.update(s => ({ ...s, error: error.message }));
-        console.error('Failed to create subtask:', error);
       },
     });
   }
@@ -168,7 +188,13 @@ export class TaskStore {
     const requestTask = existing.updateName(updatedName);
 
     this.updateTaskUseCase.execute(projectId, requestTask).subscribe({
-      next: (updatedTask) => {
+      next: (result) => {
+        if (!result.success) {
+          this.setResultError(result.error, 'update task name');
+          return;
+        }
+
+        const updatedTask = result.value;
         this.state.update(s => ({
           ...s,
           tasks: {
@@ -176,10 +202,6 @@ export class TaskStore {
             [taskId]: requestTask.updateName(updatedTask.name),
           },
         }));
-      },
-      error: (error) => {
-        this.state.update(s => ({ ...s, error: error.message }));
-        console.error('Failed to update task name:', error);
       },
     });
   }
@@ -192,8 +214,7 @@ export class TaskStore {
         onDeleted?.();
       },
       error: (error) => {
-        this.state.update(s => ({ ...s, error: error.message }));
-        console.error('Failed to delete task:', error);
+        this.setError(error.message, null, 'delete task', error);
       },
     });
   }

--- a/src/app/shared/utils/result.ts
+++ b/src/app/shared/utils/result.ts
@@ -1,0 +1,11 @@
+export type Result<T, E> =
+  | { success: true; value: T }
+  | { success: false; error: E };
+
+export function ok<T>(value: T): Result<T, never> {
+  return { success: true, value };
+}
+
+export function fail<E>(error: E): Result<never, E> {
+  return { success: false, error };
+}


### PR DESCRIPTION
This pull request introduces a new, consistent error handling approach for project and section use cases. It adds a unified `ProjectsError` type, updates all create and update use cases (and their tests) to return a `Result` object that encapsulates both success and failure (including validation and network errors), and ensures that all validation and repository errors are handled in a standardized way.

The most important changes are:

**Error Handling Infrastructure:**
* Added a new `ProjectsError` type that enumerates all possible validation and network errors for projects and sections.

**Use Case Refactoring (Projects):**
* Updated `CreateProjectUseCase` and `UpdateProjectUseCase` to use the new `Result` type, returning validation errors if the name is invalid and mapping repository errors to `NETWORK_ERROR`. 

**Use Case Refactoring (Sections):**
* Refactored `CreateSectionUseCase` and `UpdateSectionUseCase` to use the new `Result` type, including validation and error mapping.

**Test Updates:**
* Updated all affected tests to check for the new `Result` structure, including validation and network error cases.

**Test Helper Improvements:**
* Added a `validProjectName` helper function in tests to safely create valid `ProjectName` instances using the new validation logic.

These changes ensure that all project and section operations now have robust, type-safe error handling and consistent validation, making the codebase more reliable and maintainable.