### PR TITLE
Fix/delete confirmation

### DIFF
--- a/src/app/features/projects/presentation/components/home/home.component.spec.ts
+++ b/src/app/features/projects/presentation/components/home/home.component.spec.ts
@@ -15,6 +15,8 @@ import { UpcomingComponent } from '@features/upcoming/presentation/components/up
 import { TWDSidebarMenuItem } from '@shared/ui/sidebar/sidebar-menu';
 import { ProjectViewModel } from '@features/projects/presentation/models/project.view-model';
 import { ProjectOutput } from '@features/projects/application/dtos/project-output';
+import { ModalService } from '@shared/ui/modal/modal.service';
+import { ConfirmComponent } from '@shared/ui/modal/confirm/confirm.component';
 
 describe('HomeComponent', () => {
   let fixture: ComponentFixture<HomeComponent>;
@@ -54,6 +56,10 @@ describe('HomeComponent', () => {
     pendingCountFor: vi.fn().mockReturnValue(0),
   };
 
+  const modalServiceMock = {
+    open: vi.fn(),
+  };
+
   function flushRoute(url: string): void {
     routerUrl = url;
     routerEvents$.next(new NavigationEnd(1, url, url));
@@ -68,6 +74,7 @@ describe('HomeComponent', () => {
     projectStoreMock.projects.set([]);
     projectStoreMock.selectedProjectId.set(null);
     activatedRouteMock.snapshot.paramMap = convertToParamMap({ id: 'p1' });
+    modalServiceMock.open.mockReset();
 
     await TestBed.configureTestingModule({
       imports: [HomeComponent],
@@ -77,6 +84,7 @@ describe('HomeComponent', () => {
         { provide: ActivatedRoute, useValue: activatedRouteMock },
         { provide: ProjectStore, useValue: projectStoreMock },
         { provide: ProjectSummaryStore, useValue: projectSummaryStoreMock },
+        { provide: ModalService, useValue: modalServiceMock },
       ],
     }).compileComponents();
 
@@ -154,8 +162,32 @@ describe('HomeComponent', () => {
       expect(projectStoreMock.toggleProjectFavorite).toHaveBeenCalledWith('pid');
     });
 
-    it('delegates delete to project store', () => {
+    it('opens delete confirmation modal for a project', () => {
+      projectStoreMock.projects.set([{ id: 'pid', name: 'Inbox', favorite: false, sectionIds: [] }]);
+
       component['onSidebarDeleteClick']('pid');
+
+      expect(modalServiceMock.open).toHaveBeenCalledWith(
+        ConfirmComponent,
+        expect.objectContaining({
+          title: 'Delete Project',
+        }),
+      );
+      expect(projectStoreMock.deleteProject).not.toHaveBeenCalled();
+    });
+
+    it('delegates delete to project store only after confirmation', () => {
+      projectStoreMock.projects.set([{ id: 'pid', name: 'Inbox', favorite: false, sectionIds: [] }]);
+
+      component['onSidebarDeleteClick']('pid');
+
+      const [, config] = modalServiceMock.open.mock.calls[0] as [
+        typeof ConfirmComponent,
+        { onClose?: (result?: unknown) => void }
+      ];
+
+      config.onClose?.(true);
+
       expect(projectStoreMock.deleteProject).toHaveBeenCalledWith('pid');
     });
 

--- a/src/app/features/projects/presentation/components/home/home.component.ts
+++ b/src/app/features/projects/presentation/components/home/home.component.ts
@@ -11,6 +11,7 @@ import { ProjectSummaryStore } from '@features/projects/presentation/store/proje
 import { TWDSidebarMenu, TWDSidebarMenuItem } from '@shared/ui/sidebar/sidebar-menu';
 import { ModalService } from '@shared/ui/modal/modal.service';
 import { CreateProjectComponent } from '@features/projects/presentation/components/create-project/create-project.component';
+import { ConfirmComponent } from '@shared/ui/modal/confirm/confirm.component';
 
 @Component({
   selector: 'app-home',
@@ -148,7 +149,21 @@ export class HomeComponent implements OnInit, OnDestroy {
   }
 
   protected onSidebarDeleteClick(projectId: string): void {
-    this.projectStore.deleteProject(projectId);
+    const project = this.projectStore.projects().find((p) => p.id === projectId);
+    if (!project) return;
+
+    this.modalService.open(ConfirmComponent, {
+      title: 'Delete Project',
+      data: {
+        message: `Delete project "${project.name}" and all its sections and tasks? This action cannot be undone.`,
+        confirmLabel: 'Delete project',
+        cancelLabel: 'Cancel',
+      },
+      onClose: (confirmed?: unknown) => {
+        if (confirmed !== true) return;
+        this.projectStore.deleteProject(projectId);
+      },
+    });
   }
 
   protected openCreateProjectModal(): void {

--- a/src/app/features/projects/presentation/components/home/home.component.ts
+++ b/src/app/features/projects/presentation/components/home/home.component.ts
@@ -155,7 +155,8 @@ export class HomeComponent implements OnInit, OnDestroy {
     this.modalService.open(ConfirmComponent, {
       title: 'Delete Project',
       data: {
-        message: `Delete project "${project.name}" and all its sections and tasks? This action cannot be undone.`,
+        entityName: project.name,
+        cascadeMessage: 'This will also delete all sections and tasks in this project.',
         confirmLabel: 'Delete project',
         cancelLabel: 'Cancel',
       },

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.spec.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.spec.ts
@@ -4,10 +4,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ProjectSectionComponent } from '@features/projects/presentation/components/home/project-view/project-section/project-section.component';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { SectionViewModel } from '@features/projects/presentation/models/project.view-model';
+import { ModalService } from '@shared/ui/modal/modal.service';
+import { ConfirmComponent } from '@shared/ui/modal/confirm/confirm.component';
 
 describe('ProjectSectionComponent', () => {
   let component: ProjectSectionComponent;
   let fixture: ComponentFixture<ProjectSectionComponent>;
+  let modalServiceMock: { open: ReturnType<typeof vi.fn> };
 
   const section: SectionViewModel = {
     id: 's1',
@@ -17,9 +20,16 @@ describe('ProjectSectionComponent', () => {
   };
 
   beforeEach(async () => {
+    modalServiceMock = {
+      open: vi.fn(),
+    };
+
     await TestBed.configureTestingModule({
       imports: [ProjectSectionComponent],
-      providers: [provideZonelessChangeDetection()],
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: ModalService, useValue: modalServiceMock },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ProjectSectionComponent);
@@ -67,11 +77,36 @@ describe('ProjectSectionComponent', () => {
     expect(emitSpy).toHaveBeenCalledWith({ id: 's1', name: 'New Name' });
   });
 
-  it('emits sectionDelete with section id when Delete is clicked', () => {
+  it('opens confirmation modal when Delete is clicked', () => {
+    component['menuOpen'].set(true);
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector('.section-menu-item--danger').click();
+
+    expect(modalServiceMock.open).toHaveBeenCalledWith(
+      ConfirmComponent,
+      expect.objectContaining({
+        title: 'Delete Section',
+      }),
+    );
+  });
+
+  it('emits sectionDelete only after confirmation', () => {
     const emitSpy = vi.spyOn(component.sectionDelete, 'emit');
     component['menuOpen'].set(true);
     fixture.detectChanges();
+
     fixture.nativeElement.querySelector('.section-menu-item--danger').click();
+
+    expect(emitSpy).not.toHaveBeenCalled();
+
+    const [, config] = modalServiceMock.open.mock.calls[0] as [
+      typeof ConfirmComponent,
+      { onClose?: (result?: unknown) => void }
+    ];
+
+    config.onClose?.(true);
+
     expect(emitSpy).toHaveBeenCalledWith({ id: 's1' });
   });
 

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, linkedSignal, output, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input, linkedSignal, output, signal, ChangeDetectionStrategy, inject } from '@angular/core';
 import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import { AutoFocusDirective } from '@shared/directives/auto-focus.directive';
 import {
@@ -11,6 +11,8 @@ import {
   TaskToggleEvent,
 } from '@features/projects/presentation/models/project.view-model';
 import { TaskComponent } from '@features/projects/presentation/components/home/project-view/project-section/task/task.component';
+import { ModalService } from '@shared/ui/modal/modal.service';
+import { ConfirmComponent } from '@shared/ui/modal/confirm/confirm.component';
 
 @Component({
   selector: 'app-project-section',
@@ -20,6 +22,8 @@ import { TaskComponent } from '@features/projects/presentation/components/home/p
   styleUrl: './project-section.component.css',
 })
 export class ProjectSectionComponent {
+  private readonly modalService = inject(ModalService);
+
   public sectionInfo = input.required<SectionViewModel>();
   public taskToggle = output<TaskToggleEvent>();
   public taskCreate = output<TaskCreateEvent>();
@@ -105,7 +109,19 @@ export class ProjectSectionComponent {
   protected onDelete(event: Event): void {
     event.stopPropagation();
     this.menuOpen.set(false);
-    this.sectionDelete.emit({ id: this.sectionInfo().id });
+
+    this.modalService.open(ConfirmComponent, {
+      title: 'Delete Section',
+      data: {
+        message: `Delete section "${this.sectionInfo().name}" and all its tasks? This action cannot be undone.`,
+        confirmLabel: 'Delete section',
+        cancelLabel: 'Cancel',
+      },
+      onClose: (confirmed?: unknown) => {
+        if (confirmed !== true) return;
+        this.sectionDelete.emit({ id: this.sectionInfo().id });
+      },
+    });
   }
 
   protected openTaskForm(): void {

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.ts
@@ -113,7 +113,8 @@ export class ProjectSectionComponent {
     this.modalService.open(ConfirmComponent, {
       title: 'Delete Section',
       data: {
-        message: `Delete section "${this.sectionInfo().name}" and all its tasks? This action cannot be undone.`,
+        entityName: this.sectionInfo().name,
+        cascadeMessage: 'This will also delete all tasks in this section.',
         confirmLabel: 'Delete section',
         cancelLabel: 'Cancel',
       },

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.spec.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.spec.ts
@@ -4,10 +4,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TaskComponent } from '@features/projects/presentation/components/home/project-view/project-section/task/task.component';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { TaskViewModel } from '@features/projects/presentation/models/project.view-model';
+import { ModalService } from '@shared/ui/modal/modal.service';
+import { ConfirmComponent } from '@shared/ui/modal/confirm/confirm.component';
 
 describe('TaskComponent', () => {
   let component: TaskComponent;
   let fixture: ComponentFixture<TaskComponent>;
+  let modalServiceMock: { open: ReturnType<typeof vi.fn> };
 
   const task: TaskViewModel = {
     id: 't1',
@@ -18,9 +21,16 @@ describe('TaskComponent', () => {
   };
 
   beforeEach(async () => {
+    modalServiceMock = {
+      open: vi.fn(),
+    };
+
     await TestBed.configureTestingModule({
       imports: [TaskComponent],
-      providers: [provideZonelessChangeDetection()],
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: ModalService, useValue: modalServiceMock },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TaskComponent);
@@ -82,7 +92,22 @@ describe('TaskComponent', () => {
     expect(fixture.nativeElement.querySelector('.task-cancel-btn')).toBeNull();
   });
 
-  it('emits taskDelete when delete is clicked in menu', () => {
+  it('opens confirmation modal when delete is clicked in menu', () => {
+    fixture.nativeElement.querySelector('.task-menu-trigger').click();
+    fixture.detectChanges();
+
+    const deleteBtn: HTMLElement = fixture.nativeElement.querySelector('.task-menu-item--danger');
+    deleteBtn.click();
+
+    expect(modalServiceMock.open).toHaveBeenCalledWith(
+      ConfirmComponent,
+      expect.objectContaining({
+        title: 'Delete Task',
+      }),
+    );
+  });
+
+  it('emits taskDelete only after confirmation', () => {
     const emitSpy = vi.spyOn(component.taskDelete, 'emit');
 
     fixture.nativeElement.querySelector('.task-menu-trigger').click();
@@ -90,6 +115,15 @@ describe('TaskComponent', () => {
 
     const deleteBtn: HTMLElement = fixture.nativeElement.querySelector('.task-menu-item--danger');
     deleteBtn.click();
+
+    expect(emitSpy).not.toHaveBeenCalled();
+
+    const [, config] = modalServiceMock.open.mock.calls[0] as [
+      typeof ConfirmComponent,
+      { onClose?: (result?: unknown) => void }
+    ];
+
+    config.onClose?.(true);
 
     expect(emitSpy).toHaveBeenCalledWith({ id: 't1', sectionId: 's1' });
   });

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.ts
@@ -1,4 +1,4 @@
-import { Component, forwardRef, input, output, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, forwardRef, input, output, signal, ChangeDetectionStrategy, inject } from '@angular/core';
 import { NgClass } from '@angular/common';
 import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import {
@@ -8,6 +8,8 @@ import {
   TaskViewModel,
 } from '@features/projects/presentation/models/project.view-model';
 import { AutoFocusDirective } from '@shared/directives/auto-focus.directive';
+import { ModalService } from '@shared/ui/modal/modal.service';
+import { ConfirmComponent } from '@shared/ui/modal/confirm/confirm.component';
 
 @Component({
   selector: 'app-task',
@@ -17,6 +19,8 @@ import { AutoFocusDirective } from '@shared/directives/auto-focus.directive';
   styleUrl: './task.component.css',
 })
 export class TaskComponent {
+  private readonly modalService = inject(ModalService);
+
   public taskInfo = input.required<TaskViewModel>();
   public sectionId = input.required<string>();
 
@@ -93,7 +97,19 @@ export class TaskComponent {
   protected onDelete(event: Event): void {
     event.stopPropagation();
     this.menuOpen.set(false);
-    this.taskDelete.emit({ id: this.taskInfo().id, sectionId: this.sectionId() });
+
+    this.modalService.open(ConfirmComponent, {
+      title: 'Delete Task',
+      data: {
+        message: `Delete task "${this.taskInfo().name}"? This action cannot be undone.`,
+        confirmLabel: 'Delete task',
+        cancelLabel: 'Cancel',
+      },
+      onClose: (confirmed?: unknown) => {
+        if (confirmed !== true) return;
+        this.taskDelete.emit({ id: this.taskInfo().id, sectionId: this.sectionId() });
+      },
+    });
   }
 
   protected forwardTaskToggle(event: TaskToggleEvent): void {

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.ts
@@ -101,7 +101,7 @@ export class TaskComponent {
     this.modalService.open(ConfirmComponent, {
       title: 'Delete Task',
       data: {
-        message: `Delete task "${this.taskInfo().name}"? This action cannot be undone.`,
+        entityName: this.taskInfo().name,
         confirmLabel: 'Delete task',
         cancelLabel: 'Cancel',
       },

--- a/src/app/shared/ui/modal/confirm/confirm.component.css
+++ b/src/app/shared/ui/modal/confirm/confirm.component.css
@@ -2,6 +2,8 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  padding: 1.25rem 1.5rem;
+  box-sizing: border-box;
 }
 
 .confirm-modal-message {

--- a/src/app/shared/ui/modal/confirm/confirm.component.css
+++ b/src/app/shared/ui/modal/confirm/confirm.component.css
@@ -1,0 +1,39 @@
+.confirm-modal {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.confirm-modal-message {
+  margin: 0;
+  color: #3d3d3d;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.confirm-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.confirm-modal-cancel,
+.confirm-modal-confirm {
+  border: 1px solid transparent;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-weight: 600;
+  padding: 0.5rem 1rem;
+}
+
+.confirm-modal-cancel {
+  background: #f3f4f6;
+  border-color: #d1d5db;
+  color: #374151;
+}
+
+.confirm-modal-confirm {
+  background: #dc2626;
+  color: #ffffff;
+}

--- a/src/app/shared/ui/modal/confirm/confirm.component.html
+++ b/src/app/shared/ui/modal/confirm/confirm.component.html
@@ -1,0 +1,7 @@
+<div class="confirm-modal">
+  <p class="confirm-modal-message">{{ message }}</p>
+  <div class="confirm-modal-actions">
+    <button type="button" class="confirm-modal-cancel" (click)="cancel()">{{ cancelLabel }}</button>
+    <button type="button" class="confirm-modal-confirm" (click)="confirm()">{{ confirmLabel }}</button>
+  </div>
+</div>

--- a/src/app/shared/ui/modal/confirm/confirm.component.html
+++ b/src/app/shared/ui/modal/confirm/confirm.component.html
@@ -1,5 +1,11 @@
 <div class="confirm-modal">
-  <p class="confirm-modal-message">{{ message }}</p>
+  <p class="confirm-modal-message">
+    Are you sure you want to delete <strong>"{{ entityName }}"</strong>?
+    This item will be deleted <strong>permanently</strong>.
+    @if (cascadeMessage) {
+      {{ cascadeMessage }}
+    }
+  </p>
   <div class="confirm-modal-actions">
     <button type="button" class="confirm-modal-cancel" (click)="cancel()">{{ cancelLabel }}</button>
     <button type="button" class="confirm-modal-confirm" (click)="confirm()">{{ confirmLabel }}</button>

--- a/src/app/shared/ui/modal/confirm/confirm.component.spec.ts
+++ b/src/app/shared/ui/modal/confirm/confirm.component.spec.ts
@@ -19,7 +19,8 @@ describe('ConfirmComponent', () => {
         {
           provide: MODAL_DATA,
           useValue: {
-            message: 'Delete section "Inbox" and all its tasks? This action cannot be undone.',
+            entityName: 'Inbox',
+            cascadeMessage: 'This will also delete all tasks in this section.',
             confirmLabel: 'Delete',
             cancelLabel: 'Cancel',
           },
@@ -32,9 +33,14 @@ describe('ConfirmComponent', () => {
     fixture.detectChanges();
   });
 
-  it('renders confirmation message', () => {
+  it('renders confirmation message with bold entity name and permanent warning', () => {
     const message = fixture.nativeElement.querySelector('.confirm-modal-message') as HTMLElement;
-    expect(message.textContent?.trim()).toContain('Delete section "Inbox" and all its tasks?');
+    const strongElements = Array.from(message.querySelectorAll('strong')) as HTMLElement[];
+
+    expect(message.textContent).toContain('Are you sure you want to delete');
+    expect(message.textContent).toContain('This will also delete all tasks in this section.');
+    expect(strongElements[0]?.textContent).toBe('"Inbox"');
+    expect(strongElements[1]?.textContent).toBe('permanently');
   });
 
   it('closes with false when cancel is clicked', () => {

--- a/src/app/shared/ui/modal/confirm/confirm.component.spec.ts
+++ b/src/app/shared/ui/modal/confirm/confirm.component.spec.ts
@@ -1,0 +1,53 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ConfirmComponent } from '@shared/ui/modal/confirm/confirm.component';
+import { MODAL_DATA, ModalRef } from '@shared/ui/modal/modal-ref';
+
+describe('ConfirmComponent', () => {
+  let fixture: ComponentFixture<ConfirmComponent>;
+  let modalRef: ModalRef<boolean>;
+
+  beforeEach(async () => {
+    modalRef = { close: vi.fn() } as unknown as ModalRef<boolean>;
+
+    await TestBed.configureTestingModule({
+      imports: [ConfirmComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        {
+          provide: MODAL_DATA,
+          useValue: {
+            message: 'Delete section "Inbox" and all its tasks? This action cannot be undone.',
+            confirmLabel: 'Delete',
+            cancelLabel: 'Cancel',
+          },
+        },
+        { provide: ModalRef, useValue: modalRef },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ConfirmComponent);
+    fixture.detectChanges();
+  });
+
+  it('renders confirmation message', () => {
+    const message = fixture.nativeElement.querySelector('.confirm-modal-message') as HTMLElement;
+    expect(message.textContent?.trim()).toContain('Delete section "Inbox" and all its tasks?');
+  });
+
+  it('closes with false when cancel is clicked', () => {
+    const cancelButton = fixture.nativeElement.querySelector('.confirm-modal-cancel') as HTMLButtonElement;
+    cancelButton.click();
+
+    expect(modalRef.close).toHaveBeenCalledWith(false);
+  });
+
+  it('closes with true when confirm is clicked', () => {
+    const confirmButton = fixture.nativeElement.querySelector('.confirm-modal-confirm') as HTMLButtonElement;
+    confirmButton.click();
+
+    expect(modalRef.close).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/app/shared/ui/modal/confirm/confirm.component.ts
+++ b/src/app/shared/ui/modal/confirm/confirm.component.ts
@@ -1,0 +1,32 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { MODAL_DATA, ModalRef } from '@shared/ui/modal/modal-ref';
+
+interface ConfirmModalData {
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+}
+
+@Component({
+  selector: 'app-confirm-modal',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './confirm.component.html',
+  styleUrl: './confirm.component.css',
+})
+export class ConfirmComponent {
+  private readonly modalRef = inject(ModalRef<boolean>);
+  private readonly modalData = inject<ConfirmModalData>(MODAL_DATA);
+
+  protected readonly message = this.modalData.message;
+  protected readonly confirmLabel = this.modalData.confirmLabel ?? 'Delete';
+  protected readonly cancelLabel = this.modalData.cancelLabel ?? 'Cancel';
+
+  protected confirm(): void {
+    this.modalRef.close(true);
+  }
+
+  protected cancel(): void {
+    this.modalRef.close(false);
+  }
+}

--- a/src/app/shared/ui/modal/confirm/confirm.component.ts
+++ b/src/app/shared/ui/modal/confirm/confirm.component.ts
@@ -2,7 +2,8 @@ import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { MODAL_DATA, ModalRef } from '@shared/ui/modal/modal-ref';
 
 interface ConfirmModalData {
-  message: string;
+  entityName: string;
+  cascadeMessage?: string;
   confirmLabel?: string;
   cancelLabel?: string;
 }
@@ -18,7 +19,8 @@ export class ConfirmComponent {
   private readonly modalRef = inject(ModalRef<boolean>);
   private readonly modalData = inject<ConfirmModalData>(MODAL_DATA);
 
-  protected readonly message = this.modalData.message;
+  protected readonly entityName = this.modalData.entityName;
+  protected readonly cascadeMessage = this.modalData.cascadeMessage;
   protected readonly confirmLabel = this.modalData.confirmLabel ?? 'Delete';
   protected readonly cancelLabel = this.modalData.cancelLabel ?? 'Cancel';
 

--- a/src/app/shared/ui/modal/modal.component.html
+++ b/src/app/shared/ui/modal/modal.component.html
@@ -1,9 +1,9 @@
 @if (activeModal()) {
-<div class="modal-backdrop" tabindex="0" (keydown.enter)="close()" (click)="close()">
+<div class="modal-backdrop" tabindex="0" (keydown.enter)="dismiss()" (click)="dismiss()">
   <div class="modal-container" tabindex="0" (keydown.enter)="$event.stopPropagation()" (click)="$event.stopPropagation()">
     <div class="modal-header">
       <span class="modal-title">{{ title() }}</span>
-      <button class="modal-close" (click)="close()">&#10005;</button>
+      <button class="modal-close" (click)="dismiss()">&#10005;</button>
     </div>
     <div class="modal-body">
       <ng-container #outlet />

--- a/src/app/shared/ui/modal/modal.component.html
+++ b/src/app/shared/ui/modal/modal.component.html
@@ -1,9 +1,9 @@
 @if (activeModal()) {
-<div class="modal-backdrop" tabindex="0" (keydown.enter)="dismiss()" (click)="dismiss()">
+<div class="modal-backdrop" tabindex="0" (keydown.enter)="close()" (click)="close()">
   <div class="modal-container" tabindex="0" (keydown.enter)="$event.stopPropagation()" (click)="$event.stopPropagation()">
     <div class="modal-header">
       <span class="modal-title">{{ title() }}</span>
-      <button class="modal-close" (click)="dismiss()">&#10005;</button>
+      <button class="modal-close" (click)="close()">&#10005;</button>
     </div>
     <div class="modal-body">
       <ng-container #outlet />

--- a/src/app/shared/ui/modal/modal.component.spec.ts
+++ b/src/app/shared/ui/modal/modal.component.spec.ts
@@ -59,6 +59,7 @@ describe('ModalComponent', () => {
     backdrop.triggerEventHandler('click');
 
     expect(closeSpy).toHaveBeenCalledTimes(1);
+    expect(closeSpy).toHaveBeenCalledWith();
   });
 
   it('closes when header close button is clicked', () => {
@@ -70,6 +71,7 @@ describe('ModalComponent', () => {
     closeButton.triggerEventHandler('click');
 
     expect(closeSpy).toHaveBeenCalledTimes(1);
+    expect(closeSpy).toHaveBeenCalledWith();
   });
 
   it('clears backdrop after close', () => {

--- a/src/app/shared/ui/modal/modal.component.ts
+++ b/src/app/shared/ui/modal/modal.component.ts
@@ -23,7 +23,7 @@ export class ModalComponent {
   readonly activeModal = computed(() => this.modalService.activeModal());
   readonly title = computed(() => this.modalService.activeModal()?.config.title ?? '');
 
-  dismiss(): void {
+  close(): void {
     this.modalService.close();
   }
 

--- a/src/app/shared/ui/modal/modal.component.ts
+++ b/src/app/shared/ui/modal/modal.component.ts
@@ -23,8 +23,8 @@ export class ModalComponent {
   readonly activeModal = computed(() => this.modalService.activeModal());
   readonly title = computed(() => this.modalService.activeModal()?.config.title ?? '');
 
-  close(): void {
-    this.modalService.close();
+  close(result?: unknown): void {
+    this.modalService.close(result);
   }
 
   private renderContent(vcr: ViewContainerRef): void {
@@ -38,7 +38,7 @@ export class ModalComponent {
       providers: [
         {
           provide: ModalRef,
-          useValue: new ModalRef(() => this.close()),
+          useValue: new ModalRef((result: unknown) => this.close(result)),
         },
         {
           provide: MODAL_DATA,

--- a/src/app/shared/ui/modal/modal.component.ts
+++ b/src/app/shared/ui/modal/modal.component.ts
@@ -23,7 +23,11 @@ export class ModalComponent {
   readonly activeModal = computed(() => this.modalService.activeModal());
   readonly title = computed(() => this.modalService.activeModal()?.config.title ?? '');
 
-  close(result?: unknown): void {
+  dismiss(): void {
+    this.modalService.close();
+  }
+
+  private closeWithResult(result?: unknown): void {
     this.modalService.close(result);
   }
 
@@ -38,7 +42,7 @@ export class ModalComponent {
       providers: [
         {
           provide: ModalRef,
-          useValue: new ModalRef((result: unknown) => this.close(result)),
+          useValue: new ModalRef((result: unknown) => this.closeWithResult(result)),
         },
         {
           provide: MODAL_DATA,

--- a/src/app/shared/ui/modal/modal.service.spec.ts
+++ b/src/app/shared/ui/modal/modal.service.spec.ts
@@ -1,6 +1,6 @@
 import { Component, provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ModalService } from '@shared/ui/modal/modal.service';
 
 @Component({ selector: 'app-stub', template: '', standalone: true })
@@ -56,5 +56,14 @@ describe('ModalService', () => {
     service.close();
 
     expect(service.activeModal()).toBeNull();
+  });
+
+  it('invokes onClose callback with close result', () => {
+    const onClose = vi.fn();
+    service.open(StubComponent, { title: 'Confirm', onClose });
+
+    service.close(true);
+
+    expect(onClose).toHaveBeenCalledWith(true);
   });
 });

--- a/src/app/shared/ui/modal/modal.service.ts
+++ b/src/app/shared/ui/modal/modal.service.ts
@@ -3,6 +3,7 @@ import { Injectable, signal, Type } from '@angular/core';
 export interface ModalConfig {
   title: string;
   data?: Record<string, unknown>;
+  onClose?: (result?: unknown) => void;
 }
 
 export interface ActiveModal {
@@ -20,7 +21,9 @@ export class ModalService {
     this.activeModal.set({ component, config });
   }
 
-  close(): void {
+  close(result?: unknown): void {
+    const modal = this.activeModal();
     this.activeModal.set(null);
+    modal?.config.onClose?.(result);
   }
 }


### PR DESCRIPTION
This pull request introduces a reusable confirmation modal to the UI and refactors project, section, and task deletion flows to require user confirmation before proceeding. It also adds comprehensive tests for the new confirmation logic and modal component, ensuring improved safety and user experience for destructive actions.

**Confirmation Modal Implementation:**

* Added a new `ConfirmComponent` with corresponding HTML, CSS, and unit tests, providing a standardized confirmation dialog for destructive actions. 

**Project, Section, and Task Deletion Flow Changes:**

* Updated `HomeComponent`, `ProjectSectionComponent`, and `TaskComponent` to use the confirmation modal before deleting projects, sections, or tasks, ensuring deletions only proceed after user confirmation. 
**Testing Improvements:**

* Refactored and extended unit tests for the affected components to verify that the confirmation modal is shown and that deletions only occur after confirmation. (`*.spec.ts` files for HomeComponent, ProjectSectionComponent, and TaskComponent) 

**Dependency Injection and Mocks:**

* Injected `ModalService` into relevant components and provided test mocks to support modal interactions in unit tests.

Overall, these changes improve the safety and consistency of destructive actions in the UI by requiring explicit user confirmation and provide a reusable modal component for future use.