### PR TITLE
refactor(a11y): replace interactive divs with semantic buttons and align tests

### DIFF
--- a/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.css
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.css
@@ -96,6 +96,9 @@
                         justify-content: center;
                         padding: 3px;
                         border-radius: 5px;
+                        border: none;
+                        background: none;
+                        font: inherit;
                         cursor: pointer;
                         color: #555;
 
@@ -111,6 +114,9 @@
                         width: 100vw;
                         height: 100vh;
                         z-index: 99;
+                        border: none;
+                        background: transparent;
+                        padding: 0;
                     }
 
                     & .section-menu-dropdown {
@@ -270,6 +276,11 @@
                 align-items: center;
                 padding-inline: 8px;
                 padding-block: 8px;
+                width: 100%;
+                border: none;
+                background: none;
+                font: inherit;
+                text-align: left;
                 color: var(--main-color);
                 user-select: none;
                 border-radius: 6px;

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.html
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.html
@@ -30,20 +30,20 @@
                     <span class="section-task-count">{{ sectionInfo().taskCount }}</span>
                 </div>
                 <div class="section-menu-wrapper">
-                    <div
+                    <button
+                        type="button"
                         class="section-menu-trigger"
-                        tabindex="0"
                         (click)="toggleMenu($event)"
-                        (keydown.enter)="toggleMenu($event)"
+                        aria-label="Open section menu"
                     >
                         <svg width="18px" height="18px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                             <path d="M14 12C14 13.1046 13.1046 14 12 14C10.8954 14 10 13.1046 10 12C10 10.8954 10.8954 10 12 10C13.1046 10 14 10.8954 14 12Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
                             <path d="M21 12C21 13.1046 20.1046 14 19 14C17.8954 14 17 13.1046 17 12C17 10.8954 17.8954 10 19 10C20.1046 10 21 10.8954 21 12Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
                             <path d="M7 12C7 13.1046 6.10457 14 5 14C3.89543 14 3 13.1046 3 12C3 10.8954 3.89543 10 5 10C6.10457 10 7 10.8954 7 12Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
                         </svg>
-                    </div>
+                    </button>
                     @if (menuOpen()) {
-                        <div class="section-menu-backdrop" (click)="closeMenu($event)" (keydown.enter)="closeMenu($event)" tabindex="0"></div>
+                        <button type="button" class="section-menu-backdrop" (click)="closeMenu($event)" aria-label="Close section menu"></button>
                         <div class="section-menu-dropdown">
                             <button type="button" class="section-menu-item" (click)="onEdit($event)">
                                 <span class="section-menu-icon">
@@ -108,7 +108,7 @@
                     </div>
                 </form>
             } @else {
-                <div tabindex="0" class="add-task-button-container" (click)="openTaskForm()" (keydown.enter)="openTaskForm()">
+                <button type="button" class="add-task-button-container" (click)="openTaskForm()">
                     <div class="icon-container">
                         <svg class="icon add-task-icon" viewBox="0 0 29 29" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
                             <path
@@ -118,7 +118,7 @@
                         </svg>
                     </div>
                     <span>Add task</span>
-                </div>
+                </button>
             }
         </main>
     </div>

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.css
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.css
@@ -122,6 +122,9 @@
             align-items: center;
             justify-content: center;
             border-radius: 4px;
+            border: none;
+            background: none;
+            font: inherit;
             cursor: pointer;
             color: #555;
             padding: 2px;
@@ -135,6 +138,9 @@
             position: fixed;
             inset: 0;
             z-index: 99;
+            border: none;
+            background: transparent;
+            padding: 0;
         }
 
         & .task-menu-dropdown {

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.html
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.html
@@ -28,16 +28,16 @@
         </div>
 
         <div class="task-menu-wrapper">
-            <div class="task-menu-trigger" tabindex="0" (click)="toggleMenu($event)" (keydown.enter)="toggleMenu($event)">
+            <button type="button" class="task-menu-trigger" (click)="toggleMenu($event)" aria-label="Open task menu">
                 <svg width="16px" height="16px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M14 12C14 13.1046 13.1046 14 12 14C10.8954 14 10 13.1046 10 12C10 10.8954 10.8954 10 12 10C13.1046 10 14 10.8954 14 12Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
                     <path d="M21 12C21 13.1046 20.1046 14 19 14C17.8954 14 17 13.1046 17 12C17 10.8954 17.8954 10 19 10C20.1046 10 21 10.8954 21 12Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
                     <path d="M7 12C7 13.1046 6.10457 14 5 14C3.89543 14 3 13.1046 3 12C3 10.8954 3.89543 10 5 10C6.10457 10 7 10.8954 7 12Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
                 </svg>
-            </div>
+            </button>
 
             @if (menuOpen()) {
-                <div class="task-menu-backdrop" (click)="closeMenu($event)" (keydown.enter)="closeMenu($event)" tabindex="0"></div>
+                <button type="button" class="task-menu-backdrop" (click)="closeMenu($event)" aria-label="Close task menu"></button>
                 <div class="task-menu-dropdown">
                     <button type="button" class="task-menu-item" (click)="onEdit($event)">
                         <span class="task-menu-icon">

--- a/src/app/features/projects/presentation/components/home/project-view/section-adder/section-adder.component.css
+++ b/src/app/features/projects/presentation/components/home/project-view/section-adder/section-adder.component.css
@@ -94,6 +94,11 @@
         display: flex;
         align-items: center;
         padding-block: 10px;
+        width: 100%;
+        border: none;
+        background: none;
+        font: inherit;
+        text-align: left;
         color: var(--main-color);
         user-select: none;
 

--- a/src/app/features/projects/presentation/components/home/project-view/section-adder/section-adder.component.html
+++ b/src/app/features/projects/presentation/components/home/project-view/section-adder/section-adder.component.html
@@ -13,7 +13,7 @@
             </div>
         </form>
     } @else {
-    <div tabindex="0" class="add-section-button-container" (click)="openSectionForm()" (keydown.enter)="openSectionForm()">
+    <button type="button" class="add-section-button-container" (click)="openSectionForm()">
         <div class="icon-container">
             <svg class="icon add-section-icon" viewBox="0 0 29 29" fill="currentColor"
                 xmlns="http://www.w3.org/2000/svg">
@@ -23,6 +23,6 @@
             </svg>
         </div>
         <span>Add new section</span>
-    </div>
+    </button>
     }
 </section>

--- a/src/app/shared/ui/breadcrumb/breadcrumb.component.css
+++ b/src/app/shared/ui/breadcrumb/breadcrumb.component.css
@@ -16,6 +16,9 @@
       display: flex;
       margin-right: 10px;
       padding: 5px;
+      border: none;
+      background: none;
+      font: inherit;
     }
 
     & .invisible {

--- a/src/app/shared/ui/breadcrumb/breadcrumb.component.html
+++ b/src/app/shared/ui/breadcrumb/breadcrumb.component.html
@@ -1,12 +1,12 @@
 <div class="breadcrumb">
   <div class="breadcrumb-left-section">
-    <div class="breadcrumb-toggle-ico breadcrumb-hover" [ngClass]="{'invisible': showIcon()}" tabindex="0" (keydown.enter)="openSidebar()" (click)="openSidebar()">
+    <button type="button" class="breadcrumb-toggle-ico breadcrumb-hover" [ngClass]="{'invisible': showIcon()}" (click)="openSidebar()" aria-label="Open sidebar">
       <svg width="20px" height="20px" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="none"
         stroke="#000" stroke-width="1" stroke-linecap="round" stroke-linejoin="round">
         <rect x="1" y="1" width="14" height="14" rx="2" ry="2" />
         <line x1="5" y1="1" x2="5" y2="15" />
       </svg>
-    </div>
+    </button>
     <a href="#" class="breadcrumb-link-name breadcrumb-hover">
       <span class="breadcrumb-name">My Projects</span>
     </a>

--- a/src/app/shared/ui/modal/modal.component.css
+++ b/src/app/shared/ui/modal/modal.component.css
@@ -12,6 +12,14 @@
   padding: 16px;
   box-sizing: border-box;
 
+  & .modal-backdrop-close {
+    position: absolute;
+    inset: 0;
+    border: none;
+    background: transparent;
+    padding: 0;
+  }
+
   & .modal-container {
     /* Shared design tokens — cascade into all dynamically rendered content components */
     --modal-subtitle-size: 14px;
@@ -34,6 +42,8 @@
     animation: modalFadeIn 0.2s ease-out;
     max-height: min(90vh, 90dvh);
     overflow: hidden;
+    position: relative;
+    z-index: 1;
 
     & .modal-header {
       display: flex;

--- a/src/app/shared/ui/modal/modal.component.html
+++ b/src/app/shared/ui/modal/modal.component.html
@@ -1,6 +1,7 @@
 @if (activeModal()) {
-<div class="modal-backdrop" tabindex="0" (keydown.enter)="close()" (click)="close()">
-  <div class="modal-container" tabindex="0" (keydown.enter)="$event.stopPropagation()" (click)="$event.stopPropagation()">
+<div class="modal-backdrop">
+  <button type="button" class="modal-backdrop-close" (click)="close()" aria-label="Close modal"></button>
+  <div class="modal-container">
     <div class="modal-header">
       <span class="modal-title">{{ title() }}</span>
       <button class="modal-close" (click)="close()">&#10005;</button>

--- a/src/app/shared/ui/modal/modal.component.spec.ts
+++ b/src/app/shared/ui/modal/modal.component.spec.ts
@@ -55,7 +55,7 @@ describe('ModalComponent', () => {
     fixture.detectChanges();
 
     const closeSpy = vi.spyOn(modalService, 'close');
-    const backdrop = fixture.debugElement.query(By.css('.modal-backdrop'));
+    const backdrop = fixture.debugElement.query(By.css('.modal-backdrop-close'));
     backdrop.triggerEventHandler('click');
 
     expect(closeSpy).toHaveBeenCalledTimes(1);

--- a/src/app/shared/ui/sidebar/sidebar-menu-section/menu-section.component.css
+++ b/src/app/shared/ui/sidebar/sidebar-menu-section/menu-section.component.css
@@ -78,6 +78,9 @@
                     justify-content: center;
                     padding: 2px;
                     border-radius: 5px;
+                    border: none;
+                    background: none;
+                    font: inherit;
                     opacity: 0;
                     visibility: hidden;
                     cursor: pointer;
@@ -95,6 +98,9 @@
                     width: 100vw;
                     height: 100vh;
                     z-index: 99;
+                    border: none;
+                    background: transparent;
+                    padding: 0;
                 }
 
                 & .project-menu-dropdown {

--- a/src/app/shared/ui/sidebar/sidebar-menu-section/menu-section.component.html
+++ b/src/app/shared/ui/sidebar/sidebar-menu-section/menu-section.component.html
@@ -39,7 +39,7 @@
                 <span class="pending-tasks">{{item.pendingTasks}}</span>
                 @if (item.icon === 'project') {
                 <div class="project-menu-wrapper">
-                    <div class="project-menu-trigger" tabindex="0" (keydown.enter)="toggleProjectMenu(item.id, $event)" (click)="toggleProjectMenu(item.id, $event)">
+                    <button type="button" class="project-menu-trigger" (click)="toggleProjectMenu(item.id, $event)" aria-label="Open project menu">
                         <svg width="20px" height="20px" viewBox="0 0 24 24" fill="none"
                             xmlns="http://www.w3.org/2000/svg">
                             <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
@@ -59,9 +59,9 @@
                                     stroke-linejoin="round"></path>
                             </g>
                         </svg>
-                    </div>
+                    </button>
                     @if (openMenuProjectId() === item.id) {
-                    <div class="project-menu-backdrop" tabindex="0" (keydown.enter)="closeMenu($event)" (click)="closeMenu($event)"></div>
+                    <button type="button" class="project-menu-backdrop" (click)="closeMenu($event)" aria-label="Close project menu"></button>
                     <div class="project-menu-dropdown">
                         <button type="button" class="project-menu-item"
                             (click)="onFavoriteClick(item.id, $event)">

--- a/src/app/shared/ui/sidebar/sidebar.component.css
+++ b/src/app/shared/ui/sidebar/sidebar.component.css
@@ -29,9 +29,6 @@
 
         & .profile-dropdown {
           position: relative;
-          display: flex;
-          align-items: center;
-          padding: 5px;
 
           &.open {
             background-color: #eaeaea;
@@ -46,6 +43,17 @@
             height: 30px;
             margin-right: 10px;
             border-radius: 50%;
+          }
+
+          & .profile-dropdown-trigger {
+            display: flex;
+            align-items: center;
+            padding: 5px;
+            border: none;
+            background: none;
+            font: inherit;
+            width: 100%;
+            text-align: left;
           }
 
           & .profile-name {
@@ -67,11 +75,18 @@
             padding-block: 5px;
             margin-top: 5px;
 
+            & .dropdown-action,
             & div {
               display: flex;
               align-items: center;
               padding-inline: 7px;
               margin-inline: 7px;
+
+              border: none;
+              background: none;
+              width: calc(100% - 14px);
+              text-align: left;
+
               & a {
                 font-size: small;
                 color: black;
@@ -105,6 +120,10 @@
           align-items: center;
           justify-content: center;
           padding: 5px;
+
+          border: none;
+          background: none;
+          font: inherit;
         }
       }
     }

--- a/src/app/shared/ui/sidebar/sidebar.component.html
+++ b/src/app/shared/ui/sidebar/sidebar.component.html
@@ -2,22 +2,23 @@
   <div class="test">
     <div class="top-section">
       <div class="sidebar-profile ">
-        <div class="profile-dropdown sidebar-hover" [ngClass]="{'open' : toggleDropdownVal()}"
-          tabindex="0" (keydown.enter)="toggleDropdown()" (click)="toggleDropdown()">
-          <img class="profile-avatar" src="\Default_pfp.png" alt="Profile Picture">
-          <span class="profile-name">Oscar</span>
-          <svg id="arrow-down" width="20px" height="20px" viewBox="0 0 24 24" fill="none"
-            xmlns="http://www.w3.org/2000/svg">
-            <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
-            <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g>
-            <g id="SVGRepo_iconCarrier">
-              <path
-                d="M5.70711 9.71069C5.31658 10.1012 5.31658 10.7344 5.70711 11.1249L10.5993 16.0123C11.3805 16.7927 12.6463 16.7924 13.4271 16.0117L18.3174 11.1213C18.708 10.7308 18.708 10.0976 18.3174 9.70708C17.9269 9.31655 17.2937 9.31655 16.9032 9.70708L12.7176 13.8927C12.3271 14.2833 11.6939 14.2832 11.3034 13.8927L7.12132 9.71069C6.7308 9.32016 6.09763 9.32016 5.70711 9.71069Z"
-                fill="#0F0F0F"></path>
-            </g>
-          </svg>
+        <div class="profile-dropdown" [ngClass]="{'open' : toggleDropdownVal()}">
+          <button type="button" class="profile-dropdown-trigger sidebar-hover" (click)="toggleDropdown()" aria-label="Toggle profile menu">
+            <img class="profile-avatar" src="\Default_pfp.png" alt="Profile Picture">
+            <span class="profile-name">Oscar</span>
+            <svg id="arrow-down" width="20px" height="20px" viewBox="0 0 24 24" fill="none"
+              xmlns="http://www.w3.org/2000/svg">
+              <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
+              <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g>
+              <g id="SVGRepo_iconCarrier">
+                <path
+                  d="M5.70711 9.71069C5.31658 10.1012 5.31658 10.7344 5.70711 11.1249L10.5993 16.0123C11.3805 16.7927 12.6463 16.7924 13.4271 16.0117L18.3174 11.1213C18.708 10.7308 18.708 10.0976 18.3174 9.70708C17.9269 9.31655 17.2937 9.31655 16.9032 9.70708L12.7176 13.8927C12.3271 14.2833 11.6939 14.2832 11.3034 13.8927L7.12132 9.71069C6.7308 9.32016 6.09763 9.32016 5.70711 9.71069Z"
+                  fill="#0F0F0F"></path>
+              </g>
+            </svg>
+          </button>
           <div class="dropdown-content">
-            <div tabindex="0" (keydown.enter)="openProfileModal()" (click)="openProfileModal()">
+            <button type="button" class="dropdown-action" (click)="openProfileModal()">
               <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"
                 stroke="#000" stroke-width="1" stroke-linecap="round" stroke-linejoin="round">
                 <circle cx="12" cy="8" r="3.5" />
@@ -25,9 +26,9 @@
                 <path d="M6 20H18" />
               </svg>
               <a>Profile</a>
-            </div>
+            </button>
             <hr>
-            <div tabindex="0" (keydown.enter)="openConfigurationModal()" (click)="openConfigurationModal()">
+            <button type="button" class="dropdown-action" (click)="openConfigurationModal()">
               <svg width="24px" height="24px" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg"
                 stroke="#000" stroke-width="1" stroke-linecap="round" stroke-linejoin="round">
                 <path
@@ -36,7 +37,7 @@
                   d="M0 13V15C0 16.5478 1.17261 17.822 2.67809 17.9826C2.80588 18.3459 2.95062 18.7011 3.11133 19.0473C2.12484 20.226 2.18536 21.984 3.29291 23.0916L4.70712 24.5058C5.78946 25.5881 7.49305 25.6706 8.67003 24.7531C9.1044 24.9688 9.55383 25.159 10.0163 25.3218C10.1769 26.8273 11.4511 28 12.9993 28H14.9993C16.5471 28 17.8211 26.8279 17.9821 25.3228C18.4024 25.175 18.8119 25.0046 19.2091 24.8129C20.3823 25.6664 22.0344 25.564 23.0926 24.5058L24.5068 23.0916C25.565 22.0334 25.6674 20.3813 24.814 19.2081C25.0054 18.8113 25.1757 18.4023 25.3234 17.9824C26.8282 17.8211 28 16.5472 28 14.9996V12.9996C28 11.452 26.8282 10.1782 25.3234 10.0169C25.1605 9.55375 24.9701 9.10374 24.7541 8.66883C25.6708 7.49189 25.5882 5.78888 24.5061 4.70681L23.0919 3.29259C21.9846 2.18531 20.2271 2.12455 19.0485 3.1103C18.7017 2.94935 18.3459 2.80441 17.982 2.67647C17.8207 1.17177 16.5468 0 14.9993 0H12.9993C11.4514 0 10.1773 1.17231 10.0164 2.6775C9.60779 2.8213 9.20936 2.98653 8.82251 3.17181C7.64444 2.12251 5.83764 2.16276 4.70782 3.29259L3.2936 4.7068C2.16377 5.83664 2.12352 7.64345 3.17285 8.82152C2.98737 9.20877 2.82199 9.60763 2.67809 10.0167C1.17261 10.1773 0 11.4515 0 12.9996Z" />
               </svg>
               <a>Configuration</a>
-            </div>
+            </button>
             <hr>
             <div>
               <svg id="log-out-ico" width="24px" height="24px" viewBox="0 0 24 24" fill="none"
@@ -66,13 +67,13 @@
             </g>
           </svg>
         </div>
-        <div class="icon-nt icon-view sidebar-hover" tabindex="0" (keydown.enter)="toggleSidebar()" (click)="toggleSidebar()">
+        <button type="button" class="icon-nt icon-view sidebar-hover" (click)="toggleSidebar()" aria-label="Toggle sidebar visibility">
           <svg width="20px" height="20px" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="none"
             stroke="#000" stroke-width="1" stroke-linecap="round" stroke-linejoin="round">
             <rect x="1" y="1" width="14" height="14" rx="2" ry="2" />
             <line x1="5" y1="1" x2="5" y2="15" />
           </svg>
-        </div>
+        </button>
       </div>
     </div>
 

--- a/src/app/shared/ui/sidebar/sidebar.component.spec.ts
+++ b/src/app/shared/ui/sidebar/sidebar.component.spec.ts
@@ -78,7 +78,7 @@ describe('SidebarComponent', () => {
 
   it('opens profile modal when profile option is clicked', () => {
     const openSpy = vi.spyOn(modalService, 'open');
-    const profileOptionDE = fixture.debugElement.query(By.css('.dropdown-content div'));
+    const profileOptionDE = fixture.debugElement.query(By.css('.dropdown-content .dropdown-action'));
 
     profileOptionDE.triggerEventHandler('click');
 


### PR DESCRIPTION
Followed the best practices regarding accessibility since we were not using some properties as expected (For example, the tab-index inside a div element, instead of a button)

References for these changes:
- [WCAG 2.2 SC 2.1.1 Keyboard (all functionality operable via keyboard)](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html).
- [WCAG 2.2 SC 2.1.2 No Keyboard Trap](https://www.w3.org/WAI/WCAG22/Understanding/no-keyboard-trap.html).

Focusability and tab order (avoid tabindex hacks on non-interactive elements)
- [MDN tabindex guidance (prefer native focusable elements; avoid positive tabindex)](developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/tabindex#accessibility_concerns).
- [WCAG 2.2 SC 2.4.3 Focus Order](https://www.w3.org/WAI/WCAG22/Understanding/focus-order.html).

Name, role, value for controls (icon-only buttons need accessible name)
- [WCAG 2.2 SC 4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html).
- [ARIA accessible name computation (why aria-label on icon buttons is valid)](https://www.w3.org/TR/accname-1.2/).


Lint rules aligned with standards (Angular template a11y rules)
- click-events-have-key-events: https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin-template/docs/rules/click-events-have-key-events.md
- interactive-supports-focus: https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin-template/docs/rules/interactive-supports-focus.md

Please make sure to read all the commented references for not having any more accessibility issues in the future