### PR TITLE
Feat/task completion toggle

### DIFF
--- a/src/app/features/projects/application/use-cases/tasks/complete-task/complete-task.use-case.spec.ts
+++ b/src/app/features/projects/application/use-cases/tasks/complete-task/complete-task.use-case.spec.ts
@@ -1,0 +1,62 @@
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { of, throwError } from 'rxjs';
+
+import { CompleteTaskUseCase } from './complete-task.use-case';
+import { Task } from '@features/projects/domain/entities/task.entity';
+import { TaskRepository } from '@features/projects/domain/repositories/task.repository';
+
+describe('CompleteTaskUseCase', () => {
+  let useCase: CompleteTaskUseCase;
+  const complete = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    complete.mockImplementation(() => {
+      const task = Task.create('Task', 's1', new Date('2025-01-01'), 't1').complete();
+      return of(task);
+    });
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        CompleteTaskUseCase,
+        {
+          provide: TaskRepository,
+          useValue: {
+            create: vi.fn(),
+            update: vi.fn(),
+            complete,
+            delete: vi.fn(),
+            findById: vi.fn(),
+          },
+        },
+      ],
+    });
+
+    useCase = TestBed.inject(CompleteTaskUseCase);
+  });
+
+  it('calls repository complete endpoint with english completedDate', () => {
+    const task = Task.create('Task', 's1', new Date('2025-01-01'), 't1');
+
+    useCase.execute('p1', task).subscribe((result) => {
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+
+      expect(result.value.completed).toBe(true);
+    });
+
+    expect(complete).toHaveBeenCalledWith('p1', 's1', 't1', expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/));
+  });
+
+  it('maps repository failures to NETWORK_ERROR', () => {
+    const task = Task.create('Task', 's1', new Date('2025-01-01'), 't1');
+    complete.mockReturnValue(throwError(() => new Error('boom')));
+
+    useCase.execute('p1', task).subscribe((result) => {
+      expect(result).toEqual({ success: false, error: { code: 'NETWORK_ERROR' } });
+    });
+  });
+});

--- a/src/app/features/projects/application/use-cases/tasks/complete-task/complete-task.use-case.ts
+++ b/src/app/features/projects/application/use-cases/tasks/complete-task/complete-task.use-case.ts
@@ -6,17 +6,14 @@ import { Task } from '@features/projects/domain/entities/task.entity';
 import { TaskRepository } from '@features/projects/domain/repositories/task.repository';
 import { ProjectsError } from '@features/projects/application/errors/projects.error';
 import { Result, fail, ok } from '@shared/utils/result';
+import { formatDateToISO } from '@shared/utils/date.util';
 
 @Injectable()
 export class CompleteTaskUseCase {
   private readonly taskRepository = inject(TaskRepository);
 
   execute(projectId: string, task: Task): Observable<Result<Task, ProjectsError>> {
-    const now = new Date();
-    const year = now.getFullYear();
-    const month = String(now.getMonth() + 1).padStart(2, '0');
-    const day = String(now.getDate()).padStart(2, '0');
-    const completedDate = `${year}-${month}-${day}`;
+    const completedDate = formatDateToISO(new Date());
 
     return this.taskRepository.complete(projectId, task.sectionId, task.id, completedDate).pipe(
       map((updated): Result<Task, ProjectsError> => ok(updated)),

--- a/src/app/features/projects/application/use-cases/tasks/complete-task/complete-task.use-case.ts
+++ b/src/app/features/projects/application/use-cases/tasks/complete-task/complete-task.use-case.ts
@@ -1,0 +1,26 @@
+import { Injectable, inject } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+
+import { Task } from '@features/projects/domain/entities/task.entity';
+import { TaskRepository } from '@features/projects/domain/repositories/task.repository';
+import { ProjectsError } from '@features/projects/application/errors/projects.error';
+import { Result, fail, ok } from '@shared/utils/result';
+
+@Injectable()
+export class CompleteTaskUseCase {
+  private readonly taskRepository = inject(TaskRepository);
+
+  execute(projectId: string, task: Task): Observable<Result<Task, ProjectsError>> {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const day = String(now.getDate()).padStart(2, '0');
+    const completedDate = `${year}-${month}-${day}`;
+
+    return this.taskRepository.complete(projectId, task.sectionId, task.id, completedDate).pipe(
+      map((updated): Result<Task, ProjectsError> => ok(updated)),
+      catchError(() => of(fail<ProjectsError>({ code: 'NETWORK_ERROR' }))),
+    );
+  }
+}

--- a/src/app/features/projects/application/use-cases/tasks/toggle-task-completion/toggle-task-completion.use-case.spec.ts
+++ b/src/app/features/projects/application/use-cases/tasks/toggle-task-completion/toggle-task-completion.use-case.spec.ts
@@ -9,7 +9,8 @@ import { TaskRepository } from '@features/projects/domain/repositories/task.repo
 
 describe('ToggleTaskCompletionUseCase', () => {
   let useCase: ToggleTaskCompletionUseCase;
-  const update = vi.fn();
+  const complete = vi.fn();
+  const uncomplete = vi.fn();
 
   const start = new Date('2025-01-01');
   const open = Task.create('T', 's', start, 't1');
@@ -17,7 +18,8 @@ describe('ToggleTaskCompletionUseCase', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    update.mockImplementation((_projectId: string, task: Task) => of(task));
+    complete.mockImplementation(() => of(done));
+    uncomplete.mockImplementation(() => of(open));
 
     TestBed.configureTestingModule({
       providers: [
@@ -27,7 +29,9 @@ describe('ToggleTaskCompletionUseCase', () => {
           provide: TaskRepository,
           useValue: {
             create: vi.fn(),
-            update,
+            update: vi.fn(),
+            complete,
+            uncomplete,
             delete: vi.fn(),
             findById: vi.fn(),
           },
@@ -44,7 +48,8 @@ describe('ToggleTaskCompletionUseCase', () => {
       if (!result.success) return;
 
       expect(result.value.completed).toBe(true);
-      expect(update).toHaveBeenCalledWith('p1', expect.objectContaining({ completed: true }));
+      expect(complete).toHaveBeenCalledWith('p1', 's', 't1', expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/));
+      expect(uncomplete).not.toHaveBeenCalled();
     });
   });
 
@@ -54,12 +59,13 @@ describe('ToggleTaskCompletionUseCase', () => {
       if (!result.success) return;
 
       expect(result.value.completed).toBe(false);
-      expect(update).toHaveBeenCalledWith('p1', expect.objectContaining({ completed: false }));
+      expect(uncomplete).toHaveBeenCalledWith('p1', 's', 't1');
+      expect(complete).not.toHaveBeenCalled();
     });
   });
 
   it('returns network error when repository update fails', () => {
-    update.mockReturnValue(throwError(() => new Error('Network fail')));
+    complete.mockReturnValue(throwError(() => new Error('Network fail')));
 
     useCase.execute('p1', open).subscribe((result) => {
       expect(result.success).toBe(false);

--- a/src/app/features/projects/application/use-cases/tasks/toggle-task-completion/toggle-task-completion.use-case.spec.ts
+++ b/src/app/features/projects/application/use-cases/tasks/toggle-task-completion/toggle-task-completion.use-case.spec.ts
@@ -1,23 +1,71 @@
-import { describe, it, expect } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { of, throwError } from 'rxjs';
 
 import { ToggleTaskCompletionUseCase } from './toggle-task-completion.use-case';
 import { Task } from '@features/projects/domain/entities/task.entity';
+import { TaskRepository } from '@features/projects/domain/repositories/task.repository';
 
 describe('ToggleTaskCompletionUseCase', () => {
-  const useCase = new ToggleTaskCompletionUseCase();
+  let useCase: ToggleTaskCompletionUseCase;
+  const update = vi.fn();
+
   const start = new Date('2025-01-01');
   const open = Task.create('T', 's', start, 't1');
   const done = open.complete();
 
+  beforeEach(() => {
+    vi.clearAllMocks();
+    update.mockImplementation((_projectId: string, task: Task) => of(task));
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        ToggleTaskCompletionUseCase,
+        {
+          provide: TaskRepository,
+          useValue: {
+            create: vi.fn(),
+            update,
+            delete: vi.fn(),
+            findById: vi.fn(),
+          },
+        },
+      ],
+    });
+
+    useCase = TestBed.inject(ToggleTaskCompletionUseCase);
+  });
+
   it('returns completed task when input was incomplete', () => {
-    useCase.execute(open).subscribe((t) => {
-      expect(t.completed).toBe(true);
+    useCase.execute('p1', open).subscribe((result) => {
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+
+      expect(result.value.completed).toBe(true);
+      expect(update).toHaveBeenCalledWith('p1', expect.objectContaining({ completed: true }));
     });
   });
 
   it('returns uncompleted task when input was complete', () => {
-    useCase.execute(done).subscribe((t) => {
-      expect(t.completed).toBe(false);
+    useCase.execute('p1', done).subscribe((result) => {
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+
+      expect(result.value.completed).toBe(false);
+      expect(update).toHaveBeenCalledWith('p1', expect.objectContaining({ completed: false }));
+    });
+  });
+
+  it('returns network error when repository update fails', () => {
+    update.mockReturnValue(throwError(() => new Error('Network fail')));
+
+    useCase.execute('p1', open).subscribe((result) => {
+      expect(result.success).toBe(false);
+      if (result.success) return;
+
+      expect(result.error).toEqual({ code: 'NETWORK_ERROR' });
     });
   });
 });

--- a/src/app/features/projects/application/use-cases/tasks/toggle-task-completion/toggle-task-completion.use-case.spec.ts
+++ b/src/app/features/projects/application/use-cases/tasks/toggle-task-completion/toggle-task-completion.use-case.spec.ts
@@ -1,16 +1,17 @@
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { of, throwError } from 'rxjs';
+import { of } from 'rxjs';
 
 import { ToggleTaskCompletionUseCase } from './toggle-task-completion.use-case';
 import { Task } from '@features/projects/domain/entities/task.entity';
-import { TaskRepository } from '@features/projects/domain/repositories/task.repository';
+import { CompleteTaskUseCase } from '@features/projects/application/use-cases/tasks/complete-task/complete-task.use-case';
+import { UncompleteTaskUseCase } from '@features/projects/application/use-cases/tasks/uncomplete-task/uncomplete-task.use-case';
 
 describe('ToggleTaskCompletionUseCase', () => {
   let useCase: ToggleTaskCompletionUseCase;
-  const complete = vi.fn();
-  const uncomplete = vi.fn();
+  const completeExecute = vi.fn();
+  const uncompleteExecute = vi.fn();
 
   const start = new Date('2025-01-01');
   const open = Task.create('T', 's', start, 't1');
@@ -18,54 +19,45 @@ describe('ToggleTaskCompletionUseCase', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    complete.mockImplementation(() => of(done));
-    uncomplete.mockImplementation(() => of(open));
+    completeExecute.mockImplementation(() => of({ success: true, value: done }));
+    uncompleteExecute.mockImplementation(() => of({ success: true, value: open }));
 
     TestBed.configureTestingModule({
       providers: [
         provideZonelessChangeDetection(),
         ToggleTaskCompletionUseCase,
-        {
-          provide: TaskRepository,
-          useValue: {
-            create: vi.fn(),
-            update: vi.fn(),
-            complete,
-            uncomplete,
-            delete: vi.fn(),
-            findById: vi.fn(),
-          },
-        },
+        { provide: CompleteTaskUseCase, useValue: { execute: completeExecute } },
+        { provide: UncompleteTaskUseCase, useValue: { execute: uncompleteExecute } },
       ],
     });
 
     useCase = TestBed.inject(ToggleTaskCompletionUseCase);
   });
 
-  it('returns completed task when input was incomplete', () => {
+  it('delegates incomplete task to CompleteTaskUseCase', () => {
     useCase.execute('p1', open).subscribe((result) => {
       expect(result.success).toBe(true);
       if (!result.success) return;
 
       expect(result.value.completed).toBe(true);
-      expect(complete).toHaveBeenCalledWith('p1', 's', 't1', expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/));
-      expect(uncomplete).not.toHaveBeenCalled();
+      expect(completeExecute).toHaveBeenCalledWith('p1', open);
+      expect(uncompleteExecute).not.toHaveBeenCalled();
     });
   });
 
-  it('returns uncompleted task when input was complete', () => {
+  it('delegates completed task to UncompleteTaskUseCase', () => {
     useCase.execute('p1', done).subscribe((result) => {
       expect(result.success).toBe(true);
       if (!result.success) return;
 
       expect(result.value.completed).toBe(false);
-      expect(uncomplete).toHaveBeenCalledWith('p1', 's', 't1');
-      expect(complete).not.toHaveBeenCalled();
+      expect(uncompleteExecute).toHaveBeenCalledWith('p1', done);
+      expect(completeExecute).not.toHaveBeenCalled();
     });
   });
 
-  it('returns network error when repository update fails', () => {
-    complete.mockReturnValue(throwError(() => new Error('Network fail')));
+  it('returns delegated error from complete use case', () => {
+    completeExecute.mockReturnValue(of({ success: false, error: { code: 'NETWORK_ERROR' as const } }));
 
     useCase.execute('p1', open).subscribe((result) => {
       expect(result.success).toBe(false);

--- a/src/app/features/projects/application/use-cases/tasks/toggle-task-completion/toggle-task-completion.use-case.ts
+++ b/src/app/features/projects/application/use-cases/tasks/toggle-task-completion/toggle-task-completion.use-case.ts
@@ -1,29 +1,21 @@
 import { Injectable, inject } from '@angular/core';
-import { Observable, of } from 'rxjs';
-import { catchError, map } from 'rxjs/operators';
+import { Observable } from 'rxjs';
 import { Task } from '@features/projects/domain/entities/task.entity';
-import { TaskRepository } from '@features/projects/domain/repositories/task.repository';
 import { ProjectsError } from '@features/projects/application/errors/projects.error';
-import { Result, fail, ok } from '@shared/utils/result';
-import { formatDateToISO } from '@shared/utils/date.util';
+import { Result } from '@shared/utils/result';
+import { CompleteTaskUseCase } from '@features/projects/application/use-cases/tasks/complete-task/complete-task.use-case';
+import { UncompleteTaskUseCase } from '@features/projects/application/use-cases/tasks/uncomplete-task/uncomplete-task.use-case';
 
 @Injectable()
 export class ToggleTaskCompletionUseCase {
-  private readonly taskRepository = inject(TaskRepository);
+  private readonly completeTaskUseCase = inject(CompleteTaskUseCase);
+  private readonly uncompleteTaskUseCase = inject(UncompleteTaskUseCase);
 
   execute(projectId: string, task: Task): Observable<Result<Task, ProjectsError>> {
     if (task.completed) {
-      return this.taskRepository.uncomplete(projectId, task.sectionId, task.id).pipe(
-        map((updated): Result<Task, ProjectsError> => ok(updated)),
-        catchError(() => of(fail<ProjectsError>({ code: 'NETWORK_ERROR' }))),
-      );
+      return this.uncompleteTaskUseCase.execute(projectId, task);
     }
 
-    const completedDate = formatDateToISO(new Date());
-
-    return this.taskRepository.complete(projectId, task.sectionId, task.id, completedDate).pipe(
-      map((updated): Result<Task, ProjectsError> => ok(updated)),
-      catchError(() => of(fail<ProjectsError>({ code: 'NETWORK_ERROR' }))),
-    );
+    return this.completeTaskUseCase.execute(projectId, task);
   }
 }

--- a/src/app/features/projects/application/use-cases/tasks/toggle-task-completion/toggle-task-completion.use-case.ts
+++ b/src/app/features/projects/application/use-cases/tasks/toggle-task-completion/toggle-task-completion.use-case.ts
@@ -5,6 +5,7 @@ import { Task } from '@features/projects/domain/entities/task.entity';
 import { TaskRepository } from '@features/projects/domain/repositories/task.repository';
 import { ProjectsError } from '@features/projects/application/errors/projects.error';
 import { Result, fail, ok } from '@shared/utils/result';
+import { formatDateToISO } from '@shared/utils/date.util';
 
 @Injectable()
 export class ToggleTaskCompletionUseCase {
@@ -18,11 +19,7 @@ export class ToggleTaskCompletionUseCase {
       );
     }
 
-    const now = new Date();
-    const year = now.getFullYear();
-    const month = String(now.getMonth() + 1).padStart(2, '0');
-    const day = String(now.getDate()).padStart(2, '0');
-    const completedDate = `${year}-${month}-${day}`;
+    const completedDate = formatDateToISO(new Date());
 
     return this.taskRepository.complete(projectId, task.sectionId, task.id, completedDate).pipe(
       map((updated): Result<Task, ProjectsError> => ok(updated)),

--- a/src/app/features/projects/application/use-cases/tasks/toggle-task-completion/toggle-task-completion.use-case.ts
+++ b/src/app/features/projects/application/use-cases/tasks/toggle-task-completion/toggle-task-completion.use-case.ts
@@ -1,15 +1,21 @@
-import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { of } from 'rxjs';
+import { Injectable, inject } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 import { Task } from '@features/projects/domain/entities/task.entity';
+import { TaskRepository } from '@features/projects/domain/repositories/task.repository';
+import { ProjectsError } from '@features/projects/application/errors/projects.error';
+import { Result, fail, ok } from '@shared/utils/result';
 
 @Injectable()
 export class ToggleTaskCompletionUseCase {
-  // FIXME: Persist completion toggle in the backend.
-  // The current backend routes only support updating a task's name, so completion toggling is
-  // handled locally in the UI for now.
-  execute(task: Task): Observable<Task> {
-    const updated = task.completed ? task.uncomplete() : task.complete();
-    return of(updated);
+  private readonly taskRepository = inject(TaskRepository);
+
+  execute(projectId: string, task: Task): Observable<Result<Task, ProjectsError>> {
+    const toggledTask = task.completed ? task.uncomplete() : task.complete();
+
+    return this.taskRepository.update(projectId, toggledTask).pipe(
+      map((updated): Result<Task, ProjectsError> => ok(updated)),
+      catchError(() => of(fail<ProjectsError>({ code: 'NETWORK_ERROR' }))),
+    );
   }
 }

--- a/src/app/features/projects/application/use-cases/tasks/uncomplete-task/uncomplete-task.use-case.spec.ts
+++ b/src/app/features/projects/application/use-cases/tasks/uncomplete-task/uncomplete-task.use-case.spec.ts
@@ -1,0 +1,63 @@
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { of, throwError } from 'rxjs';
+
+import { UncompleteTaskUseCase } from './uncomplete-task.use-case';
+import { Task } from '@features/projects/domain/entities/task.entity';
+import { TaskRepository } from '@features/projects/domain/repositories/task.repository';
+
+describe('UncompleteTaskUseCase', () => {
+  let useCase: UncompleteTaskUseCase;
+  const uncomplete = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    uncomplete.mockImplementation(() => {
+      const task = Task.create('Task', 's1', new Date('2025-01-01'), 't1').complete().uncomplete();
+      return of(task);
+    });
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        UncompleteTaskUseCase,
+        {
+          provide: TaskRepository,
+          useValue: {
+            create: vi.fn(),
+            update: vi.fn(),
+            complete: vi.fn(),
+            uncomplete,
+            delete: vi.fn(),
+            findById: vi.fn(),
+          },
+        },
+      ],
+    });
+
+    useCase = TestBed.inject(UncompleteTaskUseCase);
+  });
+
+  it('calls repository uncomplete endpoint', () => {
+    const task = Task.create('Task', 's1', new Date('2025-01-01'), 't1').complete();
+
+    useCase.execute('p1', task).subscribe((result) => {
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+
+      expect(result.value.completed).toBe(false);
+    });
+
+    expect(uncomplete).toHaveBeenCalledWith('p1', 's1', 't1');
+  });
+
+  it('maps repository failures to NETWORK_ERROR', () => {
+    const task = Task.create('Task', 's1', new Date('2025-01-01'), 't1').complete();
+    uncomplete.mockReturnValue(throwError(() => new Error('boom')));
+
+    useCase.execute('p1', task).subscribe((result) => {
+      expect(result).toEqual({ success: false, error: { code: 'NETWORK_ERROR' } });
+    });
+  });
+});

--- a/src/app/features/projects/application/use-cases/tasks/uncomplete-task/uncomplete-task.use-case.ts
+++ b/src/app/features/projects/application/use-cases/tasks/uncomplete-task/uncomplete-task.use-case.ts
@@ -1,30 +1,18 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
+
 import { Task } from '@features/projects/domain/entities/task.entity';
 import { TaskRepository } from '@features/projects/domain/repositories/task.repository';
 import { ProjectsError } from '@features/projects/application/errors/projects.error';
 import { Result, fail, ok } from '@shared/utils/result';
 
 @Injectable()
-export class ToggleTaskCompletionUseCase {
+export class UncompleteTaskUseCase {
   private readonly taskRepository = inject(TaskRepository);
 
   execute(projectId: string, task: Task): Observable<Result<Task, ProjectsError>> {
-    if (task.completed) {
-      return this.taskRepository.uncomplete(projectId, task.sectionId, task.id).pipe(
-        map((updated): Result<Task, ProjectsError> => ok(updated)),
-        catchError(() => of(fail<ProjectsError>({ code: 'NETWORK_ERROR' }))),
-      );
-    }
-
-    const now = new Date();
-    const year = now.getFullYear();
-    const month = String(now.getMonth() + 1).padStart(2, '0');
-    const day = String(now.getDate()).padStart(2, '0');
-    const completedDate = `${year}-${month}-${day}`;
-
-    return this.taskRepository.complete(projectId, task.sectionId, task.id, completedDate).pipe(
+    return this.taskRepository.uncomplete(projectId, task.sectionId, task.id).pipe(
       map((updated): Result<Task, ProjectsError> => ok(updated)),
       catchError(() => of(fail<ProjectsError>({ code: 'NETWORK_ERROR' }))),
     );

--- a/src/app/features/projects/domain/repositories/task.repository.ts
+++ b/src/app/features/projects/domain/repositories/task.repository.ts
@@ -9,6 +9,7 @@ export abstract class TaskRepository {
    */
   abstract create(projectId: string, task: Task): Observable<Task>;
   abstract update(projectId: string, task: Task): Observable<Task>;
+  abstract complete(projectId: string, sectionId: string, taskId: string, completedDate: string): Observable<Task>;
 
   /**
    * For `delete` and `findById` we DO accept `sectionId` because at that point we do NOT have a

--- a/src/app/features/projects/domain/repositories/task.repository.ts
+++ b/src/app/features/projects/domain/repositories/task.repository.ts
@@ -10,6 +10,7 @@ export abstract class TaskRepository {
   abstract create(projectId: string, task: Task): Observable<Task>;
   abstract update(projectId: string, task: Task): Observable<Task>;
   abstract complete(projectId: string, sectionId: string, taskId: string, completedDate: string): Observable<Task>;
+  abstract uncomplete(projectId: string, sectionId: string, taskId: string): Observable<Task>;
 
   /**
    * For `delete` and `findById` we DO accept `sectionId` because at that point we do NOT have a

--- a/src/app/features/projects/infrastructure/dto/complete-task.dto.ts
+++ b/src/app/features/projects/infrastructure/dto/complete-task.dto.ts
@@ -1,0 +1,3 @@
+export interface CompleteTaskDto {
+  completedDate: string;
+}

--- a/src/app/features/projects/infrastructure/repositories/http-task.repository.spec.ts
+++ b/src/app/features/projects/infrastructure/repositories/http-task.repository.spec.ts
@@ -57,6 +57,22 @@ describe('HttpTaskRepository', () => {
     });
   });
 
+  it('complete PATCHes to task complete URL with completedDate', () => {
+    const completedDate = '4/21/2026, 10:30:00 AM';
+    repository.complete('p1', 'sec', 't1', completedDate).subscribe();
+    const req = httpMock.expectOne('/projects/p1/section/sec/task/t1/complete');
+    expect(req.request.method).toBe('PATCH');
+    expect(req.request.body).toEqual({ completedDate });
+    req.flush({
+      id: 1,
+      name: 'Job',
+      description: '',
+      start_date: start,
+      end_date: end,
+      completed: true,
+    });
+  });
+
   it('delete sends DELETE', () => {
     repository.delete('p1', 'sec', 't1').subscribe();
     const req = httpMock.expectOne('/projects/p1/section/sec/task/t1/delete');

--- a/src/app/features/projects/infrastructure/repositories/http-task.repository.spec.ts
+++ b/src/app/features/projects/infrastructure/repositories/http-task.repository.spec.ts
@@ -73,6 +73,21 @@ describe('HttpTaskRepository', () => {
     });
   });
 
+  it('uncomplete PATCHes to task uncomplete URL', () => {
+    repository.uncomplete('p1', 'sec', 't1').subscribe();
+    const req = httpMock.expectOne('/projects/p1/section/sec/task/t1/uncomplete');
+    expect(req.request.method).toBe('PATCH');
+    expect(req.request.body).toEqual({});
+    req.flush({
+      id: 1,
+      name: 'Job',
+      description: '',
+      start_date: start,
+      end_date: end,
+      completed: false,
+    });
+  });
+
   it('delete sends DELETE', () => {
     repository.delete('p1', 'sec', 't1').subscribe();
     const req = httpMock.expectOne('/projects/p1/section/sec/task/t1/delete');

--- a/src/app/features/projects/infrastructure/repositories/http-task.repository.ts
+++ b/src/app/features/projects/infrastructure/repositories/http-task.repository.ts
@@ -35,6 +35,12 @@ export class HttpTaskRepository extends TaskRepository {
       .pipe(map(responseDto => TaskMapper.toDomain(responseDto, sectionId)));
   }
 
+  uncomplete(projectId: string, sectionId: string, taskId: string): Observable<Task> {
+    return this.http
+      .patch<TaskDto>(`/projects/${projectId}/section/${sectionId}/task/${taskId}/uncomplete`, {}, requiresAuthContext())
+      .pipe(map(responseDto => TaskMapper.toDomain(responseDto, sectionId)));
+  }
+
   delete(projectId: string, sectionId: string, taskId: string): Observable<void> {
     return this.http.delete<void>(`/projects/${projectId}/section/${sectionId}/task/${taskId}/delete`, requiresAuthContext());
   }

--- a/src/app/features/projects/infrastructure/repositories/http-task.repository.ts
+++ b/src/app/features/projects/infrastructure/repositories/http-task.repository.ts
@@ -5,6 +5,7 @@ import { map } from 'rxjs/operators';
 import { Task } from '@features/projects/domain/entities/task.entity';
 import { TaskRepository } from '@features/projects/domain/repositories/task.repository';
 import { TaskDto } from '@features/projects/infrastructure/dto/task.dto';
+import { CompleteTaskDto } from '@features/projects/infrastructure/dto/complete-task.dto';
 import { TaskMapper } from '@features/projects/infrastructure/mappers/task.mapper';
 import { requiresAuthContext } from '@shared/interceptors/auth-context.token';
 
@@ -25,6 +26,13 @@ export class HttpTaskRepository extends TaskRepository {
     return this.http
       .put<TaskDto>(`/projects/${projectId}/section/${task.sectionId}/task/${task.id}/update`, dto, requiresAuthContext())
       .pipe(map(responseDto => TaskMapper.toDomain(responseDto, task.sectionId, task.parentTaskId)));
+  }
+
+  complete(projectId: string, sectionId: string, taskId: string, completedDate: string): Observable<Task> {
+    const dto: CompleteTaskDto = { completedDate };
+    return this.http
+      .patch<TaskDto>(`/projects/${projectId}/section/${sectionId}/task/${taskId}/complete`, dto, requiresAuthContext())
+      .pipe(map(responseDto => TaskMapper.toDomain(responseDto, sectionId)));
   }
 
   delete(projectId: string, sectionId: string, taskId: string): Observable<void> {

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.css
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.css
@@ -28,9 +28,18 @@
             display: flex;
             align-items: center;
             cursor: pointer;
+            position: relative;
 
             & .completed-button {
-                display: none;
+                position: absolute;
+                width: 1px;
+                height: 1px;
+                padding: 0;
+                margin: -1px;
+                overflow: hidden;
+                clip: rect(0, 0, 0, 0);
+                white-space: nowrap;
+                border: 0;
             }
 
             & .radio-mark {
@@ -39,6 +48,23 @@
                 border-radius: 50%;
                 border: 1px solid var(--checkbox-input-color);
                 position: relative;
+            }
+
+            & .completed-button:focus-visible+.radio-mark {
+                outline: 2px solid #1f6feb;
+                outline-offset: 2px;
+            }
+
+            & .sr-only {
+                position: absolute;
+                width: 1px;
+                height: 1px;
+                padding: 0;
+                margin: -1px;
+                overflow: hidden;
+                clip: rect(0, 0, 0, 0);
+                white-space: nowrap;
+                border: 0;
             }
 
             /* This block allows to custom the point inside the radio button */

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.html
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.html
@@ -1,8 +1,9 @@
 <div class="task-container">
     <div class="completed-button-container">
-        <label tabindex="0" class="completed-button-label" (click)="sendTaskCompletedChange()" (keydown.enter)="sendTaskCompletedChange()">
-            <input class="completed-button" [checked]="taskInfo().completed" type="checkbox" name="completed-task" />
-            <span class="radio-mark"></span>
+        <label class="completed-button-label">
+            <input class="completed-button" [checked]="taskInfo().completed" (change)="sendTaskCompletedChange()" type="checkbox" name="completed-task" />
+            <span class="radio-mark" aria-hidden="true"></span>
+            <span class="sr-only">{{ (taskInfo().completed ? 'Mark task as not completed' : 'Mark task as completed') + ': ' + taskInfo().name }}</span>
         </label>
     </div>
 

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.spec.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.spec.ts
@@ -51,8 +51,9 @@ describe('TaskComponent', () => {
 
   it('emits taskToggle when completion control is activated', () => {
     const emitSpy = vi.spyOn(component.taskToggle, 'emit');
-    const label: HTMLElement = fixture.nativeElement.querySelector('.completed-button-label');
-    label?.click();
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('.completed-button');
+    input.checked = true;
+    input.dispatchEvent(new Event('change'));
     expect(emitSpy).toHaveBeenCalledWith({ id: 't1' });
   });
 

--- a/src/app/features/projects/presentation/store/project.store.spec.ts
+++ b/src/app/features/projects/presentation/store/project.store.spec.ts
@@ -187,6 +187,14 @@ describe('ProjectStore', () => {
     expect(addTaskToSection).toHaveBeenCalledWith('s1', 't1');
   });
 
+  it('toggleTaskCompletion delegates to TaskStore using selected project id', () => {
+    store.loadProject('p1');
+
+    store.toggleTaskCompletion('t1');
+
+    expect(toggleTaskCompletion).toHaveBeenCalledWith('p1', 't1');
+  });
+
   it('disconnectFromEvents unsubscribes project and user streams', () => {
     const closeProject = vi.fn();
     const closeUser = vi.fn();

--- a/src/app/features/projects/presentation/store/project.store.ts
+++ b/src/app/features/projects/presentation/store/project.store.ts
@@ -483,7 +483,13 @@ export class ProjectStore {
 
   /** Toggle a task's completed status */
   toggleTaskCompletion(taskId: string): void {
-    this.taskStore.toggleTaskCompletion(taskId);
+    const projectId = this.state().selectedProjectId;
+    if (!projectId) {
+      console.error('Cannot toggle task completion: no project selected');
+      return;
+    }
+
+    this.taskStore.toggleTaskCompletion(projectId, taskId);
   }
 
   /** Update a task name */

--- a/src/app/features/projects/presentation/store/task.store.spec.ts
+++ b/src/app/features/projects/presentation/store/task.store.spec.ts
@@ -5,20 +5,20 @@ import { of } from 'rxjs';
 
 import { TaskStore } from './task.store';
 import { CreateTaskUseCase } from '@features/projects/application/use-cases/tasks/create-task/create-task.use-case';
-import { ToggleTaskCompletionUseCase } from '@features/projects/application/use-cases/tasks/toggle-task-completion/toggle-task-completion.use-case';
+import { CompleteTaskUseCase } from '@features/projects/application/use-cases/tasks/complete-task/complete-task.use-case';
 import { UpdateTaskUseCase } from '@features/projects/application/use-cases/tasks/update-task/update-task.use-case';
 import { DeleteTaskUseCase } from '@features/projects/application/use-cases/tasks/delete-task/delete-task.use-case';
 import { Task } from '@features/projects/domain/entities/task.entity';
 
 describe('TaskStore', () => {
   let store: TaskStore;
-  const toggleExecute = vi.fn();
+  const completeExecute = vi.fn();
   const updateExecute = vi.fn();
   const deleteExecute = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
-    toggleExecute.mockImplementation((t: Task) => of(t.complete()));
+    completeExecute.mockImplementation((_projectId: string, t: Task) => of({ success: true, value: t.complete() }));
     updateExecute.mockImplementation((_projectId: string, task: Task) => of({ success: true, value: task }));
     deleteExecute.mockReturnValue(of(void 0));
 
@@ -27,7 +27,7 @@ describe('TaskStore', () => {
         provideZonelessChangeDetection(),
         TaskStore,
         { provide: CreateTaskUseCase, useValue: { execute: vi.fn() } },
-        { provide: ToggleTaskCompletionUseCase, useValue: { execute: toggleExecute } },
+        { provide: CompleteTaskUseCase, useValue: { execute: completeExecute } },
         { provide: UpdateTaskUseCase, useValue: { execute: updateExecute } },
         { provide: DeleteTaskUseCase, useValue: { execute: deleteExecute } },
       ],
@@ -46,9 +46,20 @@ describe('TaskStore', () => {
     const start = new Date();
     const t = new Task('t1', 's', 'Name', false, start, undefined, undefined, undefined, undefined, undefined, []);
     store.mergeTasks([t]);
-    store.toggleTaskCompletion('t1');
-    expect(toggleExecute).toHaveBeenCalled();
+    store.toggleTaskCompletion('p1', 't1');
+    expect(completeExecute).toHaveBeenCalledWith('p1', expect.objectContaining({ id: 't1' }));
     expect(store.tasks()['t1']?.completed).toBe(true);
+  });
+
+  it('toggleTaskCompletion uncompletes through update use case when task is already completed', () => {
+    const t = new Task('t1', 's1', 'Done task', true, new Date(), undefined, undefined, undefined, new Date(), undefined, []);
+    store.mergeTasks([t]);
+
+    store.toggleTaskCompletion('p1', 't1');
+
+    expect(completeExecute).not.toHaveBeenCalled();
+    expect(updateExecute).toHaveBeenCalledWith('p1', expect.objectContaining({ id: 't1', completed: false }));
+    expect(store.tasks()['t1']?.completed).toBe(false);
   });
 
   it('updateTaskName updates task name when use case succeeds', () => {

--- a/src/app/features/projects/presentation/store/task.store.spec.ts
+++ b/src/app/features/projects/presentation/store/task.store.spec.ts
@@ -6,6 +6,7 @@ import { of } from 'rxjs';
 import { TaskStore } from './task.store';
 import { CreateTaskUseCase } from '@features/projects/application/use-cases/tasks/create-task/create-task.use-case';
 import { CompleteTaskUseCase } from '@features/projects/application/use-cases/tasks/complete-task/complete-task.use-case';
+import { UncompleteTaskUseCase } from '@features/projects/application/use-cases/tasks/uncomplete-task/uncomplete-task.use-case';
 import { UpdateTaskUseCase } from '@features/projects/application/use-cases/tasks/update-task/update-task.use-case';
 import { DeleteTaskUseCase } from '@features/projects/application/use-cases/tasks/delete-task/delete-task.use-case';
 import { Task } from '@features/projects/domain/entities/task.entity';
@@ -13,12 +14,14 @@ import { Task } from '@features/projects/domain/entities/task.entity';
 describe('TaskStore', () => {
   let store: TaskStore;
   const completeExecute = vi.fn();
+  const uncompleteExecute = vi.fn();
   const updateExecute = vi.fn();
   const deleteExecute = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
     completeExecute.mockImplementation((_projectId: string, t: Task) => of({ success: true, value: t.complete() }));
+    uncompleteExecute.mockImplementation((_projectId: string, t: Task) => of({ success: true, value: t.uncomplete() }));
     updateExecute.mockImplementation((_projectId: string, task: Task) => of({ success: true, value: task }));
     deleteExecute.mockReturnValue(of(void 0));
 
@@ -28,6 +31,7 @@ describe('TaskStore', () => {
         TaskStore,
         { provide: CreateTaskUseCase, useValue: { execute: vi.fn() } },
         { provide: CompleteTaskUseCase, useValue: { execute: completeExecute } },
+        { provide: UncompleteTaskUseCase, useValue: { execute: uncompleteExecute } },
         { provide: UpdateTaskUseCase, useValue: { execute: updateExecute } },
         { provide: DeleteTaskUseCase, useValue: { execute: deleteExecute } },
       ],
@@ -58,7 +62,8 @@ describe('TaskStore', () => {
     store.toggleTaskCompletion('p1', 't1');
 
     expect(completeExecute).not.toHaveBeenCalled();
-    expect(updateExecute).toHaveBeenCalledWith('p1', expect.objectContaining({ id: 't1', completed: false }));
+    expect(uncompleteExecute).toHaveBeenCalledWith('p1', expect.objectContaining({ id: 't1', completed: true }));
+    expect(updateExecute).not.toHaveBeenCalled();
     expect(store.tasks()['t1']?.completed).toBe(false);
   });
 

--- a/src/app/features/projects/presentation/store/task.store.spec.ts
+++ b/src/app/features/projects/presentation/store/task.store.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { beforeEach, describe, it, expect, vi } from 'vitest';
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 
 import { TaskStore } from './task.store';
 import { CreateTaskUseCase } from '@features/projects/application/use-cases/tasks/create-task/create-task.use-case';
@@ -49,10 +49,22 @@ describe('TaskStore', () => {
   it('toggleTaskCompletion replaces task from use case result', () => {
     const start = new Date();
     const t = new Task('t1', 's', 'Name', false, start, undefined, undefined, undefined, undefined, undefined, []);
+    const responseTask = new Task('t1', 's', 'Name', true, start, undefined, undefined, undefined, new Date(), undefined, []);
+    const pendingResult = new Subject<{ success: true; value: Task }>();
+    completeExecute.mockReturnValue(pendingResult.asObservable());
+
     store.mergeTasks([t]);
     store.toggleTaskCompletion('p1', 't1');
+
+    // UI should reflect completion immediately, before backend response.
+    expect(store.tasks()['t1']?.completed).toBe(true);
+
+    pendingResult.next({ success: true, value: responseTask });
+    pendingResult.complete();
+
     expect(completeExecute).toHaveBeenCalledWith('p1', expect.objectContaining({ id: 't1' }));
     expect(store.tasks()['t1']?.completed).toBe(true);
+    expect(store.tasks()['t1']?.completedDate).toBe(responseTask.completedDate);
   });
 
   it('toggleTaskCompletion uncompletes through update use case when task is already completed', () => {
@@ -64,6 +76,18 @@ describe('TaskStore', () => {
     expect(completeExecute).not.toHaveBeenCalled();
     expect(uncompleteExecute).toHaveBeenCalledWith('p1', expect.objectContaining({ id: 't1', completed: true }));
     expect(updateExecute).not.toHaveBeenCalled();
+    expect(store.tasks()['t1']?.completed).toBe(false);
+  });
+
+  it('toggleTaskCompletion rolls back optimistic completion when complete use case fails', () => {
+    const start = new Date();
+    const t = new Task('t1', 's', 'Name', false, start, undefined, undefined, undefined, undefined, undefined, []);
+    completeExecute.mockReturnValue(of({ success: false, error: { code: 'NETWORK_ERROR' as const } }));
+
+    store.mergeTasks([t]);
+    store.toggleTaskCompletion('p1', 't1');
+
+    expect(completeExecute).toHaveBeenCalledWith('p1', expect.objectContaining({ id: 't1' }));
     expect(store.tasks()['t1']?.completed).toBe(false);
   });
 

--- a/src/app/features/projects/presentation/store/task.store.ts
+++ b/src/app/features/projects/presentation/store/task.store.ts
@@ -1,6 +1,6 @@
 import { computed, inject, Injectable, signal } from '@angular/core';
 import { CreateTaskUseCase } from '@features/projects/application/use-cases/tasks/create-task/create-task.use-case';
-import { ToggleTaskCompletionUseCase } from '@features/projects/application/use-cases/tasks/toggle-task-completion/toggle-task-completion.use-case';
+import { CompleteTaskUseCase } from '@features/projects/application/use-cases/tasks/complete-task/complete-task.use-case';
 import { UpdateTaskUseCase } from '@features/projects/application/use-cases/tasks/update-task/update-task.use-case';
 import { DeleteTaskUseCase } from '@features/projects/application/use-cases/tasks/delete-task/delete-task.use-case';
 import { initialTaskState, TaskState } from '@features/projects/presentation/models/task-state';
@@ -19,7 +19,7 @@ import { UiError } from '@features/projects/presentation/models/ui-error';
 @Injectable({ providedIn: 'root' })
 export class TaskStore {
   private readonly createTaskUseCase = inject(CreateTaskUseCase);
-  private readonly toggleTaskUseCase = inject(ToggleTaskCompletionUseCase);
+  private readonly completeTaskUseCase = inject(CompleteTaskUseCase);
   private readonly updateTaskUseCase = inject(UpdateTaskUseCase);
   private readonly deleteTaskUseCase = inject(DeleteTaskUseCase);
 
@@ -219,16 +219,44 @@ export class TaskStore {
     });
   }
 
-  /** Toggle a task's completed status */
-  toggleTaskCompletion(taskId: string): void {
+  /** Toggle a task's completed status in backend and local state */
+  toggleTaskCompletion(projectId: string, taskId: string): void {
     const existing = this.state().tasks[taskId];
     if (!existing) return;
 
-    this.toggleTaskUseCase.execute(existing).subscribe((updatedTask) => {
-      this.state.update(s => ({
-        ...s,
-        tasks: { ...s.tasks, [updatedTask.id]: updatedTask },
-      }));
+    if (existing.completed) {
+      const requestTask = existing.uncomplete();
+
+      this.updateTaskUseCase.execute(projectId, requestTask).subscribe({
+        next: (result) => {
+          if (!result.success) {
+            this.setResultError(result.error, 'uncomplete task');
+            return;
+          }
+
+          const updatedTask = result.value;
+          this.state.update(s => ({
+            ...s,
+            tasks: { ...s.tasks, [updatedTask.id]: updatedTask },
+          }));
+        },
+      });
+      return;
+    }
+
+    this.completeTaskUseCase.execute(projectId, existing).subscribe({
+      next: (result) => {
+        if (!result.success) {
+          this.setResultError(result.error, 'complete task');
+          return;
+        }
+
+        const updatedTask = result.value;
+        this.state.update(s => ({
+          ...s,
+          tasks: { ...s.tasks, [updatedTask.id]: updatedTask },
+        }));
+      },
     });
   }
 

--- a/src/app/features/projects/presentation/store/task.store.ts
+++ b/src/app/features/projects/presentation/store/task.store.ts
@@ -226,28 +226,26 @@ export class TaskStore {
     const existing = this.state().tasks[taskId];
     if (!existing) return;
 
-    if (existing.completed) {
-      this.uncompleteTaskUseCase.execute(projectId, existing).subscribe({
-        next: (result) => {
-          if (!result.success) {
-            this.setResultError(result.error, 'uncomplete task');
-            return;
-          }
+    const optimisticTask = existing.completed ? existing.uncomplete() : existing.complete();
+    this.state.update(s => ({
+      ...s,
+      tasks: { ...s.tasks, [taskId]: optimisticTask },
+    }));
 
-          const updatedTask = result.value;
-          this.state.update(s => ({
-            ...s,
-            tasks: { ...s.tasks, [updatedTask.id]: updatedTask },
-          }));
-        },
-      });
-      return;
-    }
+    const request$ = existing.completed
+      ? this.uncompleteTaskUseCase.execute(projectId, existing)
+      : this.completeTaskUseCase.execute(projectId, existing);
+    const context = existing.completed ? 'uncomplete task' : 'complete task';
 
-    this.completeTaskUseCase.execute(projectId, existing).subscribe({
+    request$.subscribe({
       next: (result) => {
         if (!result.success) {
-          this.setResultError(result.error, 'complete task');
+          // Roll back the optimistic update when persistence fails.
+          this.state.update(s => ({
+            ...s,
+            tasks: { ...s.tasks, [taskId]: existing },
+          }));
+          this.setResultError(result.error, context);
           return;
         }
 

--- a/src/app/features/projects/presentation/store/task.store.ts
+++ b/src/app/features/projects/presentation/store/task.store.ts
@@ -1,6 +1,7 @@
 import { computed, inject, Injectable, signal } from '@angular/core';
 import { CreateTaskUseCase } from '@features/projects/application/use-cases/tasks/create-task/create-task.use-case';
 import { CompleteTaskUseCase } from '@features/projects/application/use-cases/tasks/complete-task/complete-task.use-case';
+import { UncompleteTaskUseCase } from '@features/projects/application/use-cases/tasks/uncomplete-task/uncomplete-task.use-case';
 import { UpdateTaskUseCase } from '@features/projects/application/use-cases/tasks/update-task/update-task.use-case';
 import { DeleteTaskUseCase } from '@features/projects/application/use-cases/tasks/delete-task/delete-task.use-case';
 import { initialTaskState, TaskState } from '@features/projects/presentation/models/task-state';
@@ -20,6 +21,7 @@ import { UiError } from '@features/projects/presentation/models/ui-error';
 export class TaskStore {
   private readonly createTaskUseCase = inject(CreateTaskUseCase);
   private readonly completeTaskUseCase = inject(CompleteTaskUseCase);
+  private readonly uncompleteTaskUseCase = inject(UncompleteTaskUseCase);
   private readonly updateTaskUseCase = inject(UpdateTaskUseCase);
   private readonly deleteTaskUseCase = inject(DeleteTaskUseCase);
 
@@ -225,9 +227,7 @@ export class TaskStore {
     if (!existing) return;
 
     if (existing.completed) {
-      const requestTask = existing.uncomplete();
-
-      this.updateTaskUseCase.execute(projectId, requestTask).subscribe({
+      this.uncompleteTaskUseCase.execute(projectId, existing).subscribe({
         next: (result) => {
           if (!result.success) {
             this.setResultError(result.error, 'uncomplete task');

--- a/src/app/features/projects/projects.providers.ts
+++ b/src/app/features/projects/projects.providers.ts
@@ -16,6 +16,7 @@ import { UpdateSectionUseCase } from '@features/projects/application/use-cases/s
 import { DeleteSectionUseCase } from '@features/projects/application/use-cases/sections/delete-section/delete-section.use-case';
 import { CreateTaskUseCase } from '@features/projects/application/use-cases/tasks/create-task/create-task.use-case';
 import { CompleteTaskUseCase } from '@features/projects/application/use-cases/tasks/complete-task/complete-task.use-case';
+import { UncompleteTaskUseCase } from '@features/projects/application/use-cases/tasks/uncomplete-task/uncomplete-task.use-case';
 import { UpdateTaskUseCase } from '@features/projects/application/use-cases/tasks/update-task/update-task.use-case';
 import { DeleteTaskUseCase } from '@features/projects/application/use-cases/tasks/delete-task/delete-task.use-case';
 import { ProjectStore } from '@features/projects/presentation/store/project.store';
@@ -40,6 +41,7 @@ export const PROJECT_FEATURE_PROVIDERS: Provider[] = [
   DeleteSectionUseCase,
   CreateTaskUseCase,
   CompleteTaskUseCase,
+  UncompleteTaskUseCase,
   UpdateTaskUseCase,
   DeleteTaskUseCase,
   ToggleFavoriteUseCase,

--- a/src/app/features/projects/projects.providers.ts
+++ b/src/app/features/projects/projects.providers.ts
@@ -15,7 +15,7 @@ import { CreateSectionUseCase } from '@features/projects/application/use-cases/s
 import { UpdateSectionUseCase } from '@features/projects/application/use-cases/sections/update-section/update-section.use-case';
 import { DeleteSectionUseCase } from '@features/projects/application/use-cases/sections/delete-section/delete-section.use-case';
 import { CreateTaskUseCase } from '@features/projects/application/use-cases/tasks/create-task/create-task.use-case';
-import { ToggleTaskCompletionUseCase } from '@features/projects/application/use-cases/tasks/toggle-task-completion/toggle-task-completion.use-case';
+import { CompleteTaskUseCase } from '@features/projects/application/use-cases/tasks/complete-task/complete-task.use-case';
 import { UpdateTaskUseCase } from '@features/projects/application/use-cases/tasks/update-task/update-task.use-case';
 import { DeleteTaskUseCase } from '@features/projects/application/use-cases/tasks/delete-task/delete-task.use-case';
 import { ProjectStore } from '@features/projects/presentation/store/project.store';
@@ -39,7 +39,7 @@ export const PROJECT_FEATURE_PROVIDERS: Provider[] = [
   UpdateSectionUseCase,
   DeleteSectionUseCase,
   CreateTaskUseCase,
-  ToggleTaskCompletionUseCase,
+  CompleteTaskUseCase,
   UpdateTaskUseCase,
   DeleteTaskUseCase,
   ToggleFavoriteUseCase,

--- a/src/app/shared/utils/date.util.ts
+++ b/src/app/shared/utils/date.util.ts
@@ -1,0 +1,7 @@
+export function formatDateToISO(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+}


### PR DESCRIPTION
This pull request implements full backend integration for task completion and uncompletion in the projects feature. It introduces new use cases and repository methods for marking tasks as complete or incomplete, updates the UI for accessibility, and ensures error handling for network failures. The changes also update tests to cover the new behavior and repository interactions.

**Backend integration for task completion/uncompletion:**

- Added new repository methods `complete` and `uncomplete` to `TaskRepository`, and implemented them in `HttpTaskRepository` to call the appropriate backend endpoints with the required parameters (`completedDate` for completion). 
- Introduced new use cases: `CompleteTaskUseCase` and `UncompleteTaskUseCase`, which interact with the repository and handle errors, returning a `Result` type.

**Toggle task completion logic:**

- Refactored `ToggleTaskCompletionUseCase` to use the new repository methods, handle network errors, and return a `Result` type. Updated tests to verify backend calls and error handling.

**UI and accessibility improvements:**

- Updated the task completion checkbox in `task.component.html` and `task.component.css` to be more accessible, including visually hidden labels for screen readers and improved focus styles. The completion control now uses the `change` event for toggling.

- Updated the corresponding test to trigger the new event and verify correct task toggling.

**Store integration:**

- Modified `ProjectStore` to pass the selected project ID when toggling task completion, ensuring the correct context is used for backend operations. Added a test for this delegation. 