### PR TITLE
fix: changed patch request to a post request when uncompleting tasks

### DIFF
--- a/src/app/features/projects/infrastructure/repositories/http-task.repository.spec.ts
+++ b/src/app/features/projects/infrastructure/repositories/http-task.repository.spec.ts
@@ -73,10 +73,10 @@ describe('HttpTaskRepository', () => {
     });
   });
 
-  it('uncomplete PATCHes to task uncomplete URL', () => {
+  it('uncomplete POSTs to task uncomplete URL', () => {
     repository.uncomplete('p1', 'sec', 't1').subscribe();
     const req = httpMock.expectOne('/projects/p1/section/sec/task/t1/uncomplete');
-    expect(req.request.method).toBe('PATCH');
+    expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual({});
     req.flush({
       id: 1,

--- a/src/app/features/projects/infrastructure/repositories/http-task.repository.ts
+++ b/src/app/features/projects/infrastructure/repositories/http-task.repository.ts
@@ -37,7 +37,7 @@ export class HttpTaskRepository extends TaskRepository {
 
   uncomplete(projectId: string, sectionId: string, taskId: string): Observable<Task> {
     return this.http
-      .patch<TaskDto>(`/projects/${projectId}/section/${sectionId}/task/${taskId}/uncomplete`, {}, requiresAuthContext())
+      .post<TaskDto>(`/projects/${projectId}/section/${sectionId}/task/${taskId}/uncomplete`, {}, requiresAuthContext())
       .pipe(map(responseDto => TaskMapper.toDomain(responseDto, sectionId)));
   }
 


### PR DESCRIPTION
Changed from PATCH to POST request when uncompleting tasks to align with latest backend changes