### PR TITLE
Feat/project filters

### DIFF
--- a/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.html
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.html
@@ -27,7 +27,7 @@
                     </div>
                 </div>
                 <div class="section-end-area">
-                    <span class="section-task-count">{{ sectionInfo().taskCount }}</span>
+                    <span class="section-task-count">{{ visibleTaskCount() }}</span>
                 </div>
                 <div class="section-menu-wrapper">
                     <button
@@ -77,7 +77,7 @@
             }
         </header>
         <main class="tasks-container">
-            @for (task of sectionInfo().tasks; track task.id) {
+            @for (task of filteredTasks(); track task.id) {
                 <app-task
                     [taskInfo]="task"
                     [sectionId]="sectionInfo().id"

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.spec.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.spec.ts
@@ -15,8 +15,23 @@ describe('ProjectSectionComponent', () => {
   const section: SectionViewModel = {
     id: 's1',
     name: 'Inbox',
-    taskCount: 0,
-    tasks: [],
+    taskCount: 2,
+    tasks: [
+      {
+        id: 't1',
+        name: 'Open task',
+        completed: false,
+        startDate: new Date('2026-01-01'),
+        subtasks: [],
+      },
+      {
+        id: 't2',
+        name: 'Done task',
+        completed: true,
+        startDate: new Date('2026-01-02'),
+        subtasks: [],
+      },
+    ],
   };
 
   beforeEach(async () => {
@@ -49,7 +64,35 @@ describe('ProjectSectionComponent', () => {
 
   it('renders the task count', () => {
     const count: HTMLElement = fixture.nativeElement.querySelector('.section-task-count');
-    expect(count.textContent?.trim()).toBe('0');
+    expect(count.textContent?.trim()).toBe('1');
+  });
+
+  it('renders only uncompleted tasks by default', () => {
+    const tasks = fixture.nativeElement.querySelectorAll('.task-container');
+
+    expect(tasks.length).toBe(1);
+  });
+
+  it('shows only completed tasks when filter is completed', () => {
+    fixture.componentRef.setInput('taskFilter', 'completed');
+    fixture.detectChanges();
+
+    const tasks = fixture.nativeElement.querySelectorAll('.task-container');
+    const count: HTMLElement = fixture.nativeElement.querySelector('.section-task-count');
+
+    expect(tasks.length).toBe(1);
+    expect(count.textContent?.trim()).toBe('1');
+  });
+
+  it('shows only uncompleted tasks when filter is uncompleted', () => {
+    fixture.componentRef.setInput('taskFilter', 'uncompleted');
+    fixture.detectChanges();
+
+    const tasks = fixture.nativeElement.querySelectorAll('.task-container');
+    const count: HTMLElement = fixture.nativeElement.querySelector('.section-task-count');
+
+    expect(tasks.length).toBe(1);
+    expect(count.textContent?.trim()).toBe('1');
   });
 
   it('shows Save and Cancel buttons when editing is active', () => {

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, linkedSignal, output, signal, ChangeDetectionStrategy, inject } from '@angular/core';
+import { Component, computed, input, linkedSignal, output, signal, ChangeDetectionStrategy, inject } from '@angular/core';
 import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import { AutoFocusDirective } from '@shared/directives/auto-focus.directive';
 import {
@@ -13,6 +13,7 @@ import {
 import { TaskComponent } from '@features/projects/presentation/components/home/project-view/project-section/task/task.component';
 import { ModalService } from '@shared/ui/modal/modal.service';
 import { ConfirmComponent } from '@shared/ui/modal/confirm/confirm.component';
+import { TaskFilter } from '@shared/types/task-filter.type';
 
 @Component({
   selector: 'app-project-section',
@@ -25,6 +26,7 @@ export class ProjectSectionComponent {
   private readonly modalService = inject(ModalService);
 
   public sectionInfo = input.required<SectionViewModel>();
+  public taskFilter = input<TaskFilter>('uncompleted');
   public taskToggle = output<TaskToggleEvent>();
   public taskCreate = output<TaskCreateEvent>();
   public taskRename = output<TaskRenameEvent>();
@@ -69,6 +71,21 @@ export class ProjectSectionComponent {
     if (errors['maxlength']) return 'Must be at most 50 characters';
     return null;
   }
+
+  protected filteredTasks = computed(() => {
+    const tasks = this.sectionInfo().tasks;
+
+    switch (this.taskFilter()) {
+      case 'completed':
+        return tasks.filter(task => task.completed);
+      case 'uncompleted':
+        return tasks.filter(task => !task.completed);
+      default:
+        return tasks;
+    }
+  });
+
+  protected visibleTaskCount = computed(() => this.filteredTasks().length);
 
   protected toggleMenu(event: Event): void {
     event.stopPropagation();

--- a/src/app/features/projects/presentation/components/home/project-view/project-view.component.html
+++ b/src/app/features/projects/presentation/components/home/project-view/project-view.component.html
@@ -1,6 +1,10 @@
 <section class="project-section">
   <nav>
-    <app-breadcrumb [showIcon]="showIcon()" (iconClick)="handleIconChange()"/>
+    <app-breadcrumb
+      [showIcon]="showIcon()"
+      (iconClick)="handleIconChange()"
+      (taskFilterChange)="onTaskFilterChange($event)"
+    />
   </nav>
   <header class="project-header">
     @if (projectInfo()?.name; as name) {
@@ -12,6 +16,7 @@
     @for (section of projectInfo()?.sections; track section.id) {
     <app-project-section
       [sectionInfo]="section"
+      [taskFilter]="taskFilter()"
       (taskToggle)="updateTaskToCompleted($event)"
       (taskCreate)="onTaskCreate($event)"
       (taskRename)="onTaskRename($event)"

--- a/src/app/features/projects/presentation/components/home/project-view/project-view.component.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, input, output, ChangeDetectionStrategy } from '@angular/core';
+import { Component, computed, inject, input, output, ChangeDetectionStrategy, signal } from '@angular/core';
 import { ProjectSectionComponent } from '@features/projects/presentation/components/home/project-view/project-section/project-section.component';
 import { SectionAdderComponent } from '@features/projects/presentation/components/home/project-view/section-adder/section-adder.component';
 import { ProjectNameEditorComponent } from '@features/projects/presentation/components/home/project-view/project-name-editor/project-name-editor.component';
@@ -12,6 +12,7 @@ import {
   TaskToggleEvent,
 } from '@features/projects/presentation/models/project.view-model';
 import { ProjectStore } from '@features/projects/presentation/store/project.store';
+import { TaskFilter } from '@shared/types/task-filter.type';
 
 @Component({
   selector: 'app-project-view',
@@ -22,6 +23,7 @@ import { ProjectStore } from '@features/projects/presentation/store/project.stor
 })
 export class ProjectViewComponent {
   private readonly projectStore = inject(ProjectStore);
+  protected taskFilter = signal<TaskFilter>('uncompleted');
 
   // Tunnel for hiding icon when sidebar is visible
   public showIconChange = output<boolean>();
@@ -29,6 +31,10 @@ export class ProjectViewComponent {
 
   handleIconChange() {
     this.showIconChange.emit(true);
+  }
+
+  protected onTaskFilterChange(filter: TaskFilter): void {
+    this.taskFilter.set(filter);
   }
 
   /** Denormalized project view-model, ready for the template */

--- a/src/app/shared/directives/click-outside.directive.ts
+++ b/src/app/shared/directives/click-outside.directive.ts
@@ -1,0 +1,19 @@
+import { Directive, ElementRef, HostListener, inject, output } from '@angular/core';
+
+@Directive({
+  selector: '[appClickOutside]',
+})
+export class ClickOutsideDirective {
+  public clickOutside = output<MouseEvent>();
+
+  private readonly elementRef = inject(ElementRef<HTMLElement>);
+
+  @HostListener('document:click', ['$event'])
+  handleDocumentClick(event: MouseEvent): void {
+    const target = event.target as Node | null;
+
+    if (target && !this.elementRef.nativeElement.contains(target)) {
+      this.clickOutside.emit(event);
+    }
+  }
+}

--- a/src/app/shared/types/task-filter.type.ts
+++ b/src/app/shared/types/task-filter.type.ts
@@ -1,0 +1,1 @@
+export type TaskFilter = 'all' | 'uncompleted' | 'completed';

--- a/src/app/shared/ui/breadcrumb/breadcrumb.component.css
+++ b/src/app/shared/ui/breadcrumb/breadcrumb.component.css
@@ -78,28 +78,51 @@
         position: absolute;
         top: calc(100% + 8px);
         right: 0;
-        min-width: 190px;
-        padding: 12px;
-        border: 1px solid #d9d9d9;
-        border-radius: 10px;
+        left: auto;
+        margin: 0;
+        width: max-content;
+        min-width: 220px;
+        max-width: calc(100vw - 24px);
+        padding: 14px 16px 12px;
+        border: 1px solid #d6d6d6;
+        border-radius: 16px;
         background-color: #fff;
-        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+        box-shadow: 0 10px 28px rgba(0, 0, 0, 0.08);
         z-index: 10;
+        overflow: hidden;
+        transform: translateY(-2px);
+
+        &::before {
+          content: '';
+          position: absolute;
+          top: 22px;
+          right: -7px;
+          width: 14px;
+          height: 14px;
+          background-color: #fff;
+          border-top: 1px solid #d6d6d6;
+          border-right: 1px solid #d6d6d6;
+          transform: rotate(45deg);
+        }
 
         & .task-filter-title {
-          margin: 0 0 10px 0;
-          font-size: 13px;
-          font-weight: 600;
-          color: #222;
+          margin: 0 0 12px 0;
+          font-size: 14px;
+          font-weight: 700;
+          color: #1f1f1f;
         }
 
         & .task-filter-option {
           display: flex;
           align-items: center;
-          gap: 8px;
-          font-size: 13px;
-          color: #444;
-          margin-bottom: 8px;
+          gap: 10px;
+          font-size: 14px;
+          color: #3f3f3f;
+          margin-bottom: 10px;
+
+          & input {
+            accent-color: #111;
+          }
         }
 
         & .task-filter-option:last-child {

--- a/src/app/shared/ui/breadcrumb/breadcrumb.component.css
+++ b/src/app/shared/ui/breadcrumb/breadcrumb.component.css
@@ -148,3 +148,9 @@
   cursor: pointer;
 }
 
+.breadcrumb-hover.active {
+  background-color: #eaeaea;
+  border-radius: 8px;
+  cursor: pointer;
+}
+

--- a/src/app/shared/ui/breadcrumb/breadcrumb.component.css
+++ b/src/app/shared/ui/breadcrumb/breadcrumb.component.css
@@ -66,12 +66,21 @@
     & .breadcrumb-filter-menu {
       position: relative;
 
+      & .breadcrumb-filter-trigger {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 5px;
+      }
+
       & .breadcrumb-filter-button {
         display: flex;
         border: none;
         background: none;
+        appearance: none;
         font: inherit;
         padding: 0;
+        line-height: 0;
       }
 
       & .task-filter-panel {

--- a/src/app/shared/ui/breadcrumb/breadcrumb.component.css
+++ b/src/app/shared/ui/breadcrumb/breadcrumb.component.css
@@ -55,11 +55,57 @@
   & .breadcrumb-right-section {
     display: flex;
     justify-content: flex-end;
+    align-items: center;
     padding-inline: 10px;
     width: 50%;
 
     & .breadcrumb-ico {
       margin: 2px 2px 0px 2px;
+    }
+
+    & .breadcrumb-filter-menu {
+      position: relative;
+
+      & .breadcrumb-filter-button {
+        display: flex;
+        border: none;
+        background: none;
+        font: inherit;
+        padding: 0;
+      }
+
+      & .task-filter-panel {
+        position: absolute;
+        top: calc(100% + 8px);
+        right: 0;
+        min-width: 190px;
+        padding: 12px;
+        border: 1px solid #d9d9d9;
+        border-radius: 10px;
+        background-color: #fff;
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+        z-index: 10;
+
+        & .task-filter-title {
+          margin: 0 0 10px 0;
+          font-size: 13px;
+          font-weight: 600;
+          color: #222;
+        }
+
+        & .task-filter-option {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+          font-size: 13px;
+          color: #444;
+          margin-bottom: 8px;
+        }
+
+        & .task-filter-option:last-child {
+          margin-bottom: 0;
+        }
+      }
     }
   }
 }

--- a/src/app/shared/ui/breadcrumb/breadcrumb.component.html
+++ b/src/app/shared/ui/breadcrumb/breadcrumb.component.html
@@ -17,24 +17,26 @@
   </div>
   <div class="breadcrumb-right-section">
     <div class="breadcrumb-filter-menu">
-      <button
-        type="button"
-        class="breadcrumb-hover breadcrumb-ico breadcrumb-filter-button"
-        aria-label="Filter items"
-        aria-controls="task-filter-panel"
-        [attr.aria-expanded]="showTaskFilterMenu()"
-        (click)="toggleTaskFilterMenu()"
-      >
-        <svg width="24px" height="24px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path
-            d="M4 6H20L14 13V19L10 21V13L4 6Z"
-            stroke="#000000"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
-        </svg>
-      </button>
+      <div class="breadcrumb-hover breadcrumb-ico breadcrumb-filter-trigger">
+        <button
+          type="button"
+          class="breadcrumb-filter-button"
+          aria-label="Filter items"
+          aria-controls="task-filter-panel"
+          [attr.aria-expanded]="showTaskFilterMenu()"
+          (click)="toggleTaskFilterMenu()"
+        >
+          <svg width="24px" height="24px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path
+              d="M4 6H20L14 13V19L10 21V13L4 6Z"
+              stroke="#000000"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
 
       @if (showTaskFilterMenu()) {
         <dialog id="task-filter-panel" class="task-filter-panel" aria-label="Task filter" open>

--- a/src/app/shared/ui/breadcrumb/breadcrumb.component.html
+++ b/src/app/shared/ui/breadcrumb/breadcrumb.component.html
@@ -16,7 +16,7 @@
     </div>
   </div>
   <div class="breadcrumb-right-section">
-    <div class="breadcrumb-filter-menu">
+    <div class="breadcrumb-filter-menu" appClickOutside (clickOutside)="closeTaskFilterMenu()">
       <div class="breadcrumb-hover breadcrumb-ico breadcrumb-filter-trigger" [class.active]="showTaskFilterMenu()">
         <button
           type="button"

--- a/src/app/shared/ui/breadcrumb/breadcrumb.component.html
+++ b/src/app/shared/ui/breadcrumb/breadcrumb.component.html
@@ -16,16 +16,58 @@
     </div>
   </div>
   <div class="breadcrumb-right-section">
-    <div class="breadcrumb-hover breadcrumb-ico" aria-label="Filter items">
-      <svg width="24px" height="24px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path
-          d="M4 6H20L14 13V19L10 21V13L4 6Z"
-          stroke="#000000"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        />
-      </svg>
+    <div class="breadcrumb-filter-menu">
+      <button
+        type="button"
+        class="breadcrumb-hover breadcrumb-ico breadcrumb-filter-button"
+        aria-label="Filter items"
+        aria-controls="task-filter-panel"
+        [attr.aria-expanded]="showTaskFilterMenu()"
+        (click)="toggleTaskFilterMenu()"
+      >
+        <svg width="24px" height="24px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path
+            d="M4 6H20L14 13V19L10 21V13L4 6Z"
+            stroke="#000000"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </button>
+
+      @if (showTaskFilterMenu()) {
+        <dialog id="task-filter-panel" class="task-filter-panel" aria-label="Task filter" open>
+          <p class="task-filter-title">Show tasks</p>
+          <label class="task-filter-option">
+            <input
+              type="radio"
+              name="task-filter"
+              [checked]="selectedTaskFilter() === 'all'"
+              (change)="selectTaskFilter('all')"
+            />
+            <span>All tasks</span>
+          </label>
+          <label class="task-filter-option">
+            <input
+              type="radio"
+              name="task-filter"
+              [checked]="selectedTaskFilter() === 'uncompleted'"
+              (change)="selectTaskFilter('uncompleted')"
+            />
+            <span>Uncompleted tasks</span>
+          </label>
+          <label class="task-filter-option">
+            <input
+              type="radio"
+              name="task-filter"
+              [checked]="selectedTaskFilter() === 'completed'"
+              (change)="selectTaskFilter('completed')"
+            />
+            <span>Completed tasks</span>
+          </label>
+        </dialog>
+      }
     </div>
     <div class="breadcrumb-hover breadcrumb-ico">
       <svg width="24px" height="24px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/app/shared/ui/breadcrumb/breadcrumb.component.html
+++ b/src/app/shared/ui/breadcrumb/breadcrumb.component.html
@@ -16,6 +16,17 @@
     </div>
   </div>
   <div class="breadcrumb-right-section">
+    <div class="breadcrumb-hover breadcrumb-ico" aria-label="Filter items">
+      <svg width="24px" height="24px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path
+          d="M4 6H20L14 13V19L10 21V13L4 6Z"
+          stroke="#000000"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+    </div>
     <div class="breadcrumb-hover breadcrumb-ico">
       <svg width="24px" height="24px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
         <g id="SVGRepo_bgCarrier" stroke-width="0"></g>

--- a/src/app/shared/ui/breadcrumb/breadcrumb.component.html
+++ b/src/app/shared/ui/breadcrumb/breadcrumb.component.html
@@ -17,7 +17,7 @@
   </div>
   <div class="breadcrumb-right-section">
     <div class="breadcrumb-filter-menu">
-      <div class="breadcrumb-hover breadcrumb-ico breadcrumb-filter-trigger">
+      <div class="breadcrumb-hover breadcrumb-ico breadcrumb-filter-trigger" [class.active]="showTaskFilterMenu()">
         <button
           type="button"
           class="breadcrumb-filter-button"

--- a/src/app/shared/ui/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/app/shared/ui/breadcrumb/breadcrumb.component.spec.ts
@@ -101,4 +101,19 @@ describe('BreadcrumbComponent', () => {
     expect(panel).toBeNull();
     expect(filterTrigger?.classList.contains('active')).toBe(false);
   });
+
+  it('closes task filter options when clicking outside the menu', () => {
+    const filterButton: HTMLButtonElement | null =
+      fixture.nativeElement.querySelector('.breadcrumb-filter-button');
+
+    filterButton?.click();
+    fixture.detectChanges();
+
+    document.body.click();
+    fixture.detectChanges();
+
+    const panel: HTMLElement | null = fixture.nativeElement.querySelector('#task-filter-panel');
+
+    expect(panel).toBeNull();
+  });
 });

--- a/src/app/shared/ui/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/app/shared/ui/breadcrumb/breadcrumb.component.spec.ts
@@ -116,4 +116,18 @@ describe('BreadcrumbComponent', () => {
 
     expect(panel).toBeNull();
   });
+
+  it('emits selected task filter when choosing an option', () => {
+    const emitSpy = vi.spyOn(component.taskFilterChange, 'emit');
+    const filterButton: HTMLButtonElement | null =
+      fixture.nativeElement.querySelector('.breadcrumb-filter-button');
+
+    filterButton?.click();
+    fixture.detectChanges();
+
+    const filterOptions = fixture.nativeElement.querySelectorAll('input[name="task-filter"]') as NodeListOf<HTMLInputElement>;
+    filterOptions[1]?.dispatchEvent(new Event('change'));
+
+    expect(emitSpy).toHaveBeenCalledWith('uncompleted');
+  });
 });

--- a/src/app/shared/ui/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/app/shared/ui/breadcrumb/breadcrumb.component.spec.ts
@@ -58,4 +58,39 @@ describe('BreadcrumbComponent', () => {
     expect(rightIcons[0].getAttribute('aria-label')).toBe('Filter items');
     expect(rightIcons[1].getAttribute('aria-label')).toBeNull();
   });
+
+  it('shows task filter options when clicking the filter icon', () => {
+    const filterButton: HTMLButtonElement | null =
+      fixture.nativeElement.querySelector('.breadcrumb-filter-button');
+
+    filterButton?.click();
+    fixture.detectChanges();
+
+    const panel: HTMLElement | null = fixture.nativeElement.querySelector('#task-filter-panel');
+    const optionLabels = Array.from(
+      fixture.nativeElement.querySelectorAll('.task-filter-option span') as NodeListOf<HTMLElement>
+    ).map(el => el.textContent?.trim());
+
+    expect(panel).not.toBeNull();
+    expect(panel?.tagName).toBe('DIALOG');
+    expect(optionLabels).toEqual([
+      'All tasks',
+      'Uncompleted tasks',
+      'Completed tasks',
+    ]);
+  });
+
+  it('hides task filter options when clicking the filter icon twice', () => {
+    const filterButton: HTMLButtonElement | null =
+      fixture.nativeElement.querySelector('.breadcrumb-filter-button');
+
+    filterButton?.click();
+    fixture.detectChanges();
+    filterButton?.click();
+    fixture.detectChanges();
+
+    const panel: HTMLElement | null = fixture.nativeElement.querySelector('#task-filter-panel');
+
+    expect(panel).toBeNull();
+  });
 });

--- a/src/app/shared/ui/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/app/shared/ui/breadcrumb/breadcrumb.component.spec.ts
@@ -53,15 +53,19 @@ describe('BreadcrumbComponent', () => {
 
   it('renders filter icon before the options icon in the right section', () => {
     const rightIcons = fixture.nativeElement.querySelectorAll('.breadcrumb-right-section .breadcrumb-ico');
+    const filterButton: HTMLButtonElement | null =
+      fixture.nativeElement.querySelector('.breadcrumb-filter-button');
 
     expect(rightIcons.length).toBe(2);
-    expect(rightIcons[0].getAttribute('aria-label')).toBe('Filter items');
+    expect(filterButton?.getAttribute('aria-label')).toBe('Filter items');
     expect(rightIcons[1].getAttribute('aria-label')).toBeNull();
   });
 
   it('shows task filter options when clicking the filter icon', () => {
     const filterButton: HTMLButtonElement | null =
       fixture.nativeElement.querySelector('.breadcrumb-filter-button');
+    const filterTrigger: HTMLElement | null =
+      fixture.nativeElement.querySelector('.breadcrumb-filter-trigger');
 
     filterButton?.click();
     fixture.detectChanges();
@@ -73,6 +77,7 @@ describe('BreadcrumbComponent', () => {
 
     expect(panel).not.toBeNull();
     expect(panel?.tagName).toBe('DIALOG');
+    expect(filterTrigger?.classList.contains('active')).toBe(true);
     expect(optionLabels).toEqual([
       'All tasks',
       'Uncompleted tasks',
@@ -83,6 +88,8 @@ describe('BreadcrumbComponent', () => {
   it('hides task filter options when clicking the filter icon twice', () => {
     const filterButton: HTMLButtonElement | null =
       fixture.nativeElement.querySelector('.breadcrumb-filter-button');
+    const filterTrigger: HTMLElement | null =
+      fixture.nativeElement.querySelector('.breadcrumb-filter-trigger');
 
     filterButton?.click();
     fixture.detectChanges();
@@ -92,5 +99,6 @@ describe('BreadcrumbComponent', () => {
     const panel: HTMLElement | null = fixture.nativeElement.querySelector('#task-filter-panel');
 
     expect(panel).toBeNull();
+    expect(filterTrigger?.classList.contains('active')).toBe(false);
   });
 });

--- a/src/app/shared/ui/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/app/shared/ui/breadcrumb/breadcrumb.component.spec.ts
@@ -50,4 +50,12 @@ describe('BreadcrumbComponent', () => {
     expect(emitSpy).toHaveBeenCalledWith(true);
     expect(emitSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('renders filter icon before the options icon in the right section', () => {
+    const rightIcons = fixture.nativeElement.querySelectorAll('.breadcrumb-right-section .breadcrumb-ico');
+
+    expect(rightIcons.length).toBe(2);
+    expect(rightIcons[0].getAttribute('aria-label')).toBe('Filter items');
+    expect(rightIcons[1].getAttribute('aria-label')).toBeNull();
+  });
 });

--- a/src/app/shared/ui/breadcrumb/breadcrumb.component.ts
+++ b/src/app/shared/ui/breadcrumb/breadcrumb.component.ts
@@ -1,5 +1,5 @@
 import { NgClass } from '@angular/common';
-import { Component, input, output, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input, output, ChangeDetectionStrategy, signal } from '@angular/core';
 
 @Component({
   selector: 'app-breadcrumb',
@@ -13,9 +13,19 @@ export class BreadcrumbComponent {
 
   public showIcon = input.required<boolean>();
   public iconClick = output<boolean>();
+  protected showTaskFilterMenu = signal(false);
+  protected selectedTaskFilter = signal<'all' | 'uncompleted' | 'completed'>('all');
 
   openSidebar() {
     this.iconClick.emit(true);
+  }
+
+  protected toggleTaskFilterMenu(): void {
+    this.showTaskFilterMenu.update(isOpen => !isOpen);
+  }
+
+  protected selectTaskFilter(option: 'all' | 'uncompleted' | 'completed'): void {
+    this.selectedTaskFilter.set(option);
   }
 }
 

--- a/src/app/shared/ui/breadcrumb/breadcrumb.component.ts
+++ b/src/app/shared/ui/breadcrumb/breadcrumb.component.ts
@@ -1,6 +1,7 @@
 import { NgClass } from '@angular/common';
 import { Component, input, output, ChangeDetectionStrategy, signal } from '@angular/core';
 import { ClickOutsideDirective } from '@shared/directives/click-outside.directive';
+import { TaskFilter } from '@shared/types/task-filter.type';
 
 @Component({
   selector: 'app-breadcrumb',
@@ -14,8 +15,9 @@ export class BreadcrumbComponent {
 
   public showIcon = input.required<boolean>();
   public iconClick = output<boolean>();
+  public taskFilterChange = output<TaskFilter>();
   protected showTaskFilterMenu = signal(false);
-  protected selectedTaskFilter = signal<'all' | 'uncompleted' | 'completed'>('all');
+  protected selectedTaskFilter = signal<TaskFilter>('uncompleted');
 
   openSidebar() {
     this.iconClick.emit(true);
@@ -29,8 +31,9 @@ export class BreadcrumbComponent {
     this.showTaskFilterMenu.set(false);
   }
 
-  protected selectTaskFilter(option: 'all' | 'uncompleted' | 'completed'): void {
+  protected selectTaskFilter(option: TaskFilter): void {
     this.selectedTaskFilter.set(option);
+    this.taskFilterChange.emit(option);
   }
 }
 

--- a/src/app/shared/ui/breadcrumb/breadcrumb.component.ts
+++ b/src/app/shared/ui/breadcrumb/breadcrumb.component.ts
@@ -1,10 +1,11 @@
 import { NgClass } from '@angular/common';
 import { Component, input, output, ChangeDetectionStrategy, signal } from '@angular/core';
+import { ClickOutsideDirective } from '@shared/directives/click-outside.directive';
 
 @Component({
   selector: 'app-breadcrumb',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgClass],
+  imports: [NgClass, ClickOutsideDirective],
   templateUrl: './breadcrumb.component.html',
   styleUrl: './breadcrumb.component.css',
 })
@@ -22,6 +23,10 @@ export class BreadcrumbComponent {
 
   protected toggleTaskFilterMenu(): void {
     this.showTaskFilterMenu.update(isOpen => !isOpen);
+  }
+
+  protected closeTaskFilterMenu(): void {
+    this.showTaskFilterMenu.set(false);
   }
 
   protected selectTaskFilter(option: 'all' | 'uncompleted' | 'completed'): void {


### PR DESCRIPTION
## Updating the state based on task completion filters
**Summary:** Added a new icon in the right upper side of the project view for filtering matters. This is located at the same level as the three dots for the project -> Right side of the breadcrumb.
The default filter is set to the uncompleted tasks

### 🖼️ Visual Comparison
**Before** (No option to filter):
<img width="3579" height="1852" alt="image" src="https://github.com/user-attachments/assets/d354c344-0c2d-450c-9cd8-ceaae935f7fe" />


**After**:
<img width="1280" height="662" alt="ScreencastFrom2026-04-2322-57-09-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/f12eb931-7973-4e1e-bef6-107c81d44a4a" /> 

---

## 🛠️ Technical Details
- **Components Modified:** 
  - Project section:  (Displaying the filtered tasks for each section)
  - Project view: Bridge for sending the filter form changes to the project section
  - Breadcrumb component: Where the filter icon and its form is located

