### PR TITLE
Fix/profile dropdown

### DIFF
--- a/src/app/shared/ui/sidebar/sidebar.component.html
+++ b/src/app/shared/ui/sidebar/sidebar.component.html
@@ -2,7 +2,7 @@
   <div class="test">
     <div class="top-section">
       <div class="sidebar-profile ">
-        <div class="profile-dropdown" [ngClass]="{'open' : toggleDropdownVal()}">
+        <div class="profile-dropdown" [ngClass]="{'open' : toggleDropdownVal()}" appClickOutside (clickOutside)="closeDropdown()">
           <button type="button" class="profile-dropdown-trigger sidebar-hover" (click)="toggleDropdown()" aria-label="Toggle profile menu">
             <img class="profile-avatar" src="\Default_pfp.png" alt="Profile Picture">
             <span class="profile-name">Oscar</span>

--- a/src/app/shared/ui/sidebar/sidebar.component.spec.ts
+++ b/src/app/shared/ui/sidebar/sidebar.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ModalService } from '@shared/ui/modal/modal.service';
+import { ConfigurationComponent } from '@shared/ui/modal/configuration/configuration.component';
 import { ProfileComponent } from '@shared/ui/modal/profile/profile.component';
 import { TWDSidebarMenu } from '@shared/ui/sidebar/sidebar-menu';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -103,10 +104,36 @@ describe('SidebarComponent', () => {
   it('opens profile modal when profile option is clicked', () => {
     const openSpy = vi.spyOn(modalService, 'open');
     const profileOptionDE = fixture.debugElement.query(By.css('.dropdown-content .dropdown-action'));
+    const triggerButton: HTMLButtonElement | null = fixture.nativeElement.querySelector('.profile-dropdown-trigger');
+    const dropdown: HTMLElement | null = fixture.nativeElement.querySelector('.profile-dropdown');
+
+    triggerButton?.click();
+    fixture.detectChanges();
+    expect(dropdown?.classList.contains('open')).toBe(true);
 
     profileOptionDE.triggerEventHandler('click');
+    fixture.detectChanges();
 
     expect(openSpy).toHaveBeenCalledWith(ProfileComponent, { title: 'Profile' });
+    expect(dropdown?.classList.contains('open')).toBe(false);
+  });
+
+  it('opens configuration modal and closes dropdown when configuration option is clicked', () => {
+    const openSpy = vi.spyOn(modalService, 'open');
+    const optionsDE = fixture.debugElement.queryAll(By.css('.dropdown-content .dropdown-action'));
+    const configurationOptionDE = optionsDE[1];
+    const triggerButton: HTMLButtonElement | null = fixture.nativeElement.querySelector('.profile-dropdown-trigger');
+    const dropdown: HTMLElement | null = fixture.nativeElement.querySelector('.profile-dropdown');
+
+    triggerButton?.click();
+    fixture.detectChanges();
+    expect(dropdown?.classList.contains('open')).toBe(true);
+
+    configurationOptionDE.triggerEventHandler('click');
+    fixture.detectChanges();
+
+    expect(openSpy).toHaveBeenCalledWith(ConfigurationComponent, { title: 'Configuration' });
+    expect(dropdown?.classList.contains('open')).toBe(false);
   });
 
   it('emits createProjectClick when plus icon in projects section is clicked', () => {

--- a/src/app/shared/ui/sidebar/sidebar.component.spec.ts
+++ b/src/app/shared/ui/sidebar/sidebar.component.spec.ts
@@ -73,8 +73,32 @@ describe('SidebarComponent', () => {
     expect(emitSpy).toHaveBeenCalledTimes(1);
   });
 
-  // TODO: Enable this test when profile dropdown toggle behavior is fully implemented.
-  it.todo('toggles dropdown open class when profile area is clicked');
+  it('toggles dropdown open class when profile trigger is clicked', () => {
+    const triggerButton: HTMLButtonElement | null = fixture.nativeElement.querySelector('.profile-dropdown-trigger');
+    const dropdown: HTMLElement | null = fixture.nativeElement.querySelector('.profile-dropdown');
+
+    triggerButton?.click();
+    fixture.detectChanges();
+    expect(dropdown?.classList.contains('open')).toBe(true);
+
+    triggerButton?.click();
+    fixture.detectChanges();
+    expect(dropdown?.classList.contains('open')).toBe(false);
+  });
+
+  it('closes dropdown when clicking outside', () => {
+    const triggerButton: HTMLButtonElement | null = fixture.nativeElement.querySelector('.profile-dropdown-trigger');
+    const dropdown: HTMLElement | null = fixture.nativeElement.querySelector('.profile-dropdown');
+
+    triggerButton?.click();
+    fixture.detectChanges();
+    expect(dropdown?.classList.contains('open')).toBe(true);
+
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    fixture.detectChanges();
+
+    expect(dropdown?.classList.contains('open')).toBe(false);
+  });
 
   it('opens profile modal when profile option is clicked', () => {
     const openSpy = vi.spyOn(modalService, 'open');

--- a/src/app/shared/ui/sidebar/sidebar.component.ts
+++ b/src/app/shared/ui/sidebar/sidebar.component.ts
@@ -5,11 +5,12 @@ import { ConfigurationComponent } from '@shared/ui/modal/configuration/configura
 import { ProfileComponent } from '@shared/ui/modal/profile/profile.component';
 import { TWDSidebarMenu, TWDSidebarMenuItem } from '@shared/ui/sidebar/sidebar-menu';
 import { MenuSectionComponent } from '@shared/ui/sidebar/sidebar-menu-section/menu-section.component';
+import { ClickOutsideDirective } from '@shared/directives/click-outside.directive';
 
 @Component({
   selector: 'app-sidebar',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgClass, MenuSectionComponent],
+  imports: [NgClass, MenuSectionComponent, ClickOutsideDirective],
   templateUrl: './sidebar.component.html',
   styleUrl: './sidebar.component.css',
 })
@@ -49,6 +50,10 @@ export class SidebarComponent {
 
   toggleDropdown() {
     this.toggleDropdownVal.set(!this.toggleDropdownVal());
+  }
+
+  closeDropdown(): void {
+    this.toggleDropdownVal.set(false);
   }
 
   protected favoriteSectionHasItems = computed(() => this.favoriteMenuSectionInfo().items.length > 0);

--- a/src/app/shared/ui/sidebar/sidebar.component.ts
+++ b/src/app/shared/ui/sidebar/sidebar.component.ts
@@ -33,10 +33,12 @@ export class SidebarComponent {
   public createProjectClick = output<void>();
 
   openProfileModal(): void {
+    this.closeDropdown();
     this.modalService.open(ProfileComponent, { title: 'Profile' });
   }
 
   openConfigurationModal(): void {
+    this.closeDropdown();
     this.modalService.open(ConfigurationComponent, { title: 'Configuration' });
   }
 


### PR DESCRIPTION
The profile dropdown could not be closed when clicking outside. This was solved by adding the click outside in the sidebar component as well.

## UI Changes:
Before: See issue #103 , there is a video that demonstrates this unexpected behavior.

After:

https://github.com/user-attachments/assets/223f1364-5afc-4aa2-b0ea-7a0a3a84c286


## Other small changes
I have also enabled this dropdown to close whenever you click any option that shows a modal, which did not happen before as well. You can see this when I open the profile dropdown in the above demonstration.
