### PR TITLE
Fix/user info

### DIFF
--- a/src/app/features/projects/presentation/components/home/home.component.spec.ts
+++ b/src/app/features/projects/presentation/components/home/home.component.spec.ts
@@ -17,6 +17,10 @@ import { ProjectViewModel } from '@features/projects/presentation/models/project
 import { ProjectOutput } from '@features/projects/application/dtos/project-output';
 import { ModalService } from '@shared/ui/modal/modal.service';
 import { ConfirmComponent } from '@shared/ui/modal/confirm/confirm.component';
+import { AuthStore } from '@features/auth/presentation/store/auth.store';
+import { User } from '@features/auth/domain/entities/user.entity';
+
+const mockAuthStore = { user: signal<User | null>(new User('1', 'test@example.com', 'TestUser')) };
 
 describe('HomeComponent', () => {
   let fixture: ComponentFixture<HomeComponent>;
@@ -85,6 +89,7 @@ describe('HomeComponent', () => {
         { provide: ProjectStore, useValue: projectStoreMock },
         { provide: ProjectSummaryStore, useValue: projectSummaryStoreMock },
         { provide: ModalService, useValue: modalServiceMock },
+        { provide: AuthStore, useValue: mockAuthStore },
       ],
     }).compileComponents();
 

--- a/src/app/shared/ui/modal/profile/profile.component.css
+++ b/src/app/shared/ui/modal/profile/profile.component.css
@@ -41,6 +41,13 @@
         }
       }
 
+      & .readonly-field {
+        background-color: #f5f5f5;
+        color: #777;
+        border-color: #d9d9d9;
+        cursor: not-allowed;
+      }
+
       & label {
         width: 100%;
         font-size: var(--modal-subtitle-size, 14px);

--- a/src/app/shared/ui/modal/profile/profile.component.html
+++ b/src/app/shared/ui/modal/profile/profile.component.html
@@ -10,14 +10,14 @@
   <section>
     <h3>Name</h3>
     <div>
-      <input type="text" [(ngModel)]="name">
+      <input type="text" [value]="username()" readonly>
       <button class="btn default" (click)="updateName()">Update</button>
     </div>
   </section>
   <section>
     <h3>Email</h3>
     <div>
-      <input type="text" [(ngModel)]="email">
+      <input type="text" [value]="email()" readonly>
       <button class="btn default" (click)="updateEmail()">Update</button>
     </div>
   </section>

--- a/src/app/shared/ui/modal/profile/profile.component.html
+++ b/src/app/shared/ui/modal/profile/profile.component.html
@@ -10,7 +10,7 @@
   <section>
     <h3>Name</h3>
     <div>
-      <input type="text" [(ngModel)]="username">
+      <input type="text" [(ngModel)]="editableUsername">
       <button class="btn default" (click)="updateName()">Update</button>
     </div>
   </section>

--- a/src/app/shared/ui/modal/profile/profile.component.html
+++ b/src/app/shared/ui/modal/profile/profile.component.html
@@ -10,24 +10,23 @@
   <section>
     <h3>Name</h3>
     <div>
-      <input type="text" [value]="username()" readonly>
+      <input type="text" [(ngModel)]="username">
       <button class="btn default" (click)="updateName()">Update</button>
     </div>
   </section>
   <section>
     <h3>Email</h3>
     <div>
-      <input type="text" [value]="email()" readonly>
-      <button class="btn default" (click)="updateEmail()">Update</button>
+      <input class="readonly-field" type="text" [value]="email()" readonly aria-readonly="true" title="Email cannot be edited yet">
     </div>
   </section>
   <section>
     <h3>Password</h3>
     <div>
       <label for="oldPassword">Old Password</label>
-      <input id="oldPassword" type="text" [(ngModel)]="oldPassword">
+      <input id="oldPassword" type="password" [(ngModel)]="oldPassword">
       <label for="newPassword">New Password</label>
-      <input id="newPassword" type="text" [(ngModel)]="newPassword">
+      <input id="newPassword" type="password" [(ngModel)]="newPassword">
       <button class="btn default" (click)="updatePassword()">Update</button>
     </div>
   </section>

--- a/src/app/shared/ui/modal/profile/profile.component.spec.ts
+++ b/src/app/shared/ui/modal/profile/profile.component.spec.ts
@@ -1,8 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ProfileComponent } from '@shared/ui/modal/profile/profile.component';
-import { provideZonelessChangeDetection } from '@angular/core';
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { AuthStore } from '@features/auth/presentation/store/auth.store';
+import { User } from '@features/auth/domain/entities/user.entity';
 
+const mockUser = new User('1', 'test@example.com', 'TestUser');
+const mockAuthStore = { user: signal<User | null>(mockUser) };
 
 describe('ProfileComponent', () => {
   let component: ProfileComponent;
@@ -11,7 +15,10 @@ describe('ProfileComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ProfileComponent],
-      providers: [provideZonelessChangeDetection()]
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: AuthStore, useValue: mockAuthStore },
+      ],
     })
     .compileComponents();
 

--- a/src/app/shared/ui/modal/profile/profile.component.ts
+++ b/src/app/shared/ui/modal/profile/profile.component.ts
@@ -30,10 +30,6 @@ export class ProfileComponent {
     console.log('Updated name:', this.username);
   }
 
-  updateEmail() {
-    console.log('Updated email:', this.email());
-  }
-
   updatePassword() {
     console.log('Old:', this.oldPassword, 'New:', this.newPassword);
   }

--- a/src/app/shared/ui/modal/profile/profile.component.ts
+++ b/src/app/shared/ui/modal/profile/profile.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, inject, computed } from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject, computed, effect } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { AuthStore } from '@features/auth/presentation/store/auth.store';
 
@@ -12,11 +12,18 @@ import { AuthStore } from '@features/auth/presentation/store/auth.store';
 export class ProfileComponent {
   private readonly authStore = inject(AuthStore);
 
-  username = this.authStore.user()?.username ?? '';
+  readonly username = computed(() => this.authStore.user()?.username ?? '');
+  editableUsername = '';
   readonly email = computed(() => this.authStore.user()?.email ?? '');
 
   oldPassword = '';
   newPassword = '';
+
+  constructor() {
+    effect(() => {
+      this.editableUsername = this.username();
+    });
+  }
 
   changePicture() {
     console.log('Change picture clicked');
@@ -27,7 +34,7 @@ export class ProfileComponent {
   }
 
   updateName() {
-    console.log('Updated name:', this.username);
+    console.log('Updated name:', this.editableUsername);
   }
 
   updatePassword() {

--- a/src/app/shared/ui/modal/profile/profile.component.ts
+++ b/src/app/shared/ui/modal/profile/profile.component.ts
@@ -12,7 +12,7 @@ import { AuthStore } from '@features/auth/presentation/store/auth.store';
 export class ProfileComponent {
   private readonly authStore = inject(AuthStore);
 
-  readonly username = computed(() => this.authStore.user()?.username ?? '');
+  username = this.authStore.user()?.username ?? '';
   readonly email = computed(() => this.authStore.user()?.email ?? '');
 
   oldPassword = '';
@@ -27,7 +27,7 @@ export class ProfileComponent {
   }
 
   updateName() {
-    console.log('Updated name:', this.username());
+    console.log('Updated name:', this.username);
   }
 
   updateEmail() {

--- a/src/app/shared/ui/modal/profile/profile.component.ts
+++ b/src/app/shared/ui/modal/profile/profile.component.ts
@@ -1,5 +1,6 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject, computed } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { AuthStore } from '@features/auth/presentation/store/auth.store';
 
 @Component({
   selector: 'app-profile-modal',
@@ -9,9 +10,11 @@ import { FormsModule } from '@angular/forms';
   styleUrl: './profile.component.css'
 })
 export class ProfileComponent {
+  private readonly authStore = inject(AuthStore);
 
-  name = 'Oscar';
-  email = 'oscar@gmail.com';
+  readonly username = computed(() => this.authStore.user()?.username ?? '');
+  readonly email = computed(() => this.authStore.user()?.email ?? '');
+
   oldPassword = '';
   newPassword = '';
 
@@ -24,11 +27,11 @@ export class ProfileComponent {
   }
 
   updateName() {
-    console.log('Updated name:', this.name);
+    console.log('Updated name:', this.username());
   }
 
   updateEmail() {
-    console.log('Updated email:', this.email);
+    console.log('Updated email:', this.email());
   }
 
   updatePassword() {

--- a/src/app/shared/ui/sidebar/sidebar.component.html
+++ b/src/app/shared/ui/sidebar/sidebar.component.html
@@ -5,7 +5,7 @@
         <div class="profile-dropdown" [ngClass]="{'open' : toggleDropdownVal()}" appClickOutside (clickOutside)="closeDropdown()">
           <button type="button" class="profile-dropdown-trigger sidebar-hover" (click)="toggleDropdown()" aria-label="Toggle profile menu">
             <img class="profile-avatar" src="\Default_pfp.png" alt="Profile Picture">
-            <span class="profile-name">Oscar</span>
+            <span class="profile-name">{{ user()?.username }}</span>
             <svg id="arrow-down" width="20px" height="20px" viewBox="0 0 24 24" fill="none"
               xmlns="http://www.w3.org/2000/svg">
               <g id="SVGRepo_bgCarrier" stroke-width="0"></g>

--- a/src/app/shared/ui/sidebar/sidebar.component.spec.ts
+++ b/src/app/shared/ui/sidebar/sidebar.component.spec.ts
@@ -7,7 +7,12 @@ import { TWDSidebarMenu } from '@shared/ui/sidebar/sidebar-menu';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SidebarComponent } from '@shared/ui/sidebar/sidebar.component';
-import { provideZonelessChangeDetection } from '@angular/core';
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { AuthStore } from '@features/auth/presentation/store/auth.store';
+import { User } from '@features/auth/domain/entities/user.entity';
+
+const mockUser = new User('1', 'test@example.com', 'TestUser');
+const mockAuthStore = { user: signal<User | null>(mockUser) };
 
 
 describe('SidebarComponent', () => {
@@ -38,7 +43,10 @@ describe('SidebarComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [SidebarComponent],
-      providers: [provideZonelessChangeDetection()],
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: AuthStore, useValue: mockAuthStore },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(SidebarComponent);

--- a/src/app/shared/ui/sidebar/sidebar.component.ts
+++ b/src/app/shared/ui/sidebar/sidebar.component.ts
@@ -6,6 +6,7 @@ import { ProfileComponent } from '@shared/ui/modal/profile/profile.component';
 import { TWDSidebarMenu, TWDSidebarMenuItem } from '@shared/ui/sidebar/sidebar-menu';
 import { MenuSectionComponent } from '@shared/ui/sidebar/sidebar-menu-section/menu-section.component';
 import { ClickOutsideDirective } from '@shared/directives/click-outside.directive';
+import { AuthStore } from '@features/auth/presentation/store/auth.store';
 
 @Component({
   selector: 'app-sidebar',
@@ -16,6 +17,9 @@ import { ClickOutsideDirective } from '@shared/directives/click-outside.directiv
 })
 export class SidebarComponent {
   private readonly modalService = inject(ModalService);
+  private readonly authStore = inject(AuthStore);
+
+  readonly user = computed(() => this.authStore.user());
 
   protected toggleDropdownVal = signal<boolean>(false);
 


### PR DESCRIPTION
Updated the profile info from the sidebar using an already existing auth store that saved all the user information.

This would solve both #101 and #102 issues.

I also made some UI changes as well in the profile modal. The size of the modal is still the same, no need to worry about this, just seems different in screenshot:

| Before (Showing placeholder info and email seemed like it could be changed) | After (email cannot be changed) |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/28aff2b4-2b66-4dfa-ab40-e094b0f242b3" width="400"/> | <img src="https://github.com/user-attachments/assets/a6dc8598-19cd-4050-8134-ce31de9c836b" width="400"/> |
