### PR TITLE
feat: enabled section edition when clicking over it

### DIFF
--- a/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.css
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.css
@@ -44,7 +44,7 @@
                         outline: none;
                         padding: 2px 4px;
                         border-radius: 4px;
-                        cursor: default;
+                        cursor: pointer;
                         color: inherit;
                         overflow: hidden;
                         text-overflow: ellipsis;

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.html
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.html
@@ -3,27 +3,26 @@
         <header class="section-header">
             <div class="section-header-row">
                 <div class="section-title-area">
-                    <div class="section-name-wrapper">
+                    <div class="section-name-wrapper" appClickOutside (clickOutside)="onSectionNameOutsideClick()">
+                        <input
+                            class="section-name-input"
+                            [class.editing]="editing()"
+                            [class.invalid]="sectionNameCtrl.touched && sectionNameCtrl.invalid"
+                            [formControl]="sectionNameCtrl"
+                            (click)="onSectionNameClick($event)"
+                            (keydown.enter)="onSave()"
+                            (keydown.escape)="onCancel()"
+                            [readonly]="!editing()"
+                            type="text"
+                        />
+                        @if (editing() && sectionNameCtrl.touched && sectionNameError) {
+                            <span class="field-error">{{ sectionNameError }}</span>
+                        }
                         @if (editing()) {
-                            <input
-                                class="section-name-input editing"
-                                [class.invalid]="sectionNameCtrl.touched && sectionNameCtrl.invalid"
-                                [formControl]="sectionNameCtrl"
-                                (keydown.enter)="onSave()"
-                                (keydown.escape)="onCancel()"
-                                type="text"
-                            />
-                            @if (sectionNameCtrl.touched && sectionNameError) {
-                                <span class="field-error">{{ sectionNameError }}</span>
-                            }
-                        } @else {
-                            <input
-                                class="section-name-input"
-                                [value]="sectionName()"
-                                (click)="onSectionNameClick($event)"
-                                readonly
-                                type="text"
-                            />
+                            <div class="section-edit-actions">
+                                <button type="button" class="section-save-btn" (click)="onSave()">Save</button>
+                                <button type="button" class="section-cancel-btn" (click)="onCancel()">Cancel</button>
+                            </div>
                         }
                     </div>
                 </div>
@@ -70,12 +69,6 @@
                     }
                 </div>
             </div>
-            @if (editing()) {
-                <div class="section-edit-actions">
-                    <button type="button" class="section-save-btn" (click)="onSave()">Save</button>
-                    <button type="button" class="section-cancel-btn" (click)="onCancel()">Cancel</button>
-                </div>
-            }
         </header>
         <main class="tasks-container">
             @for (task of filteredTasks(); track task.id) {

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.html
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.html
@@ -20,6 +20,7 @@
                             <input
                                 class="section-name-input"
                                 [value]="sectionName()"
+                                (click)="onSectionNameClick($event)"
                                 readonly
                                 type="text"
                             />

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.spec.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.spec.ts
@@ -66,10 +66,24 @@ describe('ProjectSectionComponent', () => {
     fixture.nativeElement.querySelector('.section-name-input').click();
     fixture.detectChanges();
 
-    const input: HTMLInputElement = fixture.nativeElement.querySelector('.section-name-input.editing');
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('.section-name-input');
     expect(input).toBeTruthy();
     expect(component['editing']()).toBe(true);
     expect(component['sectionNameCtrl'].value).toBe('Inbox');
+  });
+
+  it('cancels editing when clicking outside the section input', () => {
+    fixture.nativeElement.querySelector('.section-name-input').click();
+    fixture.detectChanges();
+
+    component['sectionNameCtrl'].setValue('Changed section name');
+    document.body.click();
+    fixture.detectChanges();
+
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('.section-name-input');
+    expect(component['editing']()).toBe(false);
+    expect(input.readOnly).toBe(true);
+    expect(input.value).toBe('Inbox');
   });
 
   it('renders the task count', () => {

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.spec.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.spec.ts
@@ -62,6 +62,16 @@ describe('ProjectSectionComponent', () => {
     expect(input.value).toBe('Inbox');
   });
 
+  it('starts editing when the section name is clicked', () => {
+    fixture.nativeElement.querySelector('.section-name-input').click();
+    fixture.detectChanges();
+
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('.section-name-input.editing');
+    expect(input).toBeTruthy();
+    expect(component['editing']()).toBe(true);
+    expect(component['sectionNameCtrl'].value).toBe('Inbox');
+  });
+
   it('renders the task count', () => {
     const count: HTMLElement = fixture.nativeElement.querySelector('.section-task-count');
     expect(count.textContent?.trim()).toBe('1');

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.ts
@@ -1,6 +1,7 @@
-import { Component, computed, input, linkedSignal, output, signal, ChangeDetectionStrategy, inject } from '@angular/core';
+import { Component, computed, effect, input, linkedSignal, output, signal, ChangeDetectionStrategy, inject } from '@angular/core';
 import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import { AutoFocusDirective } from '@shared/directives/auto-focus.directive';
+import { ClickOutsideDirective } from '@shared/directives/click-outside.directive';
 import {
   SectionDeleteEvent,
   SectionUpdateEvent,
@@ -18,7 +19,7 @@ import { TaskFilter } from '@shared/types/task-filter.type';
 @Component({
   selector: 'app-project-section',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ReactiveFormsModule, AutoFocusDirective, TaskComponent],
+  imports: [ReactiveFormsModule, AutoFocusDirective, ClickOutsideDirective, TaskComponent],
   templateUrl: './project-section.component.html',
   styleUrl: './project-section.component.css',
 })
@@ -47,6 +48,12 @@ export class ProjectSectionComponent {
   protected sectionNameCtrl = new FormControl('', {
     nonNullable: true,
     validators: [Validators.required, Validators.minLength(2), Validators.maxLength(50)],
+  });
+
+  private readonly syncSectionNameCtrl = effect(() => {
+    if (this.editing()) return;
+
+    this.sectionNameCtrl.setValue(this.sectionName(), { emitEvent: false });
   });
 
   protected newTaskNameCtrl = new FormControl('', {
@@ -96,6 +103,12 @@ export class ProjectSectionComponent {
     if (this.editing()) return;
 
     this.onEdit(event);
+  }
+
+  protected onSectionNameOutsideClick(): void {
+    if (!this.editing()) return;
+
+    this.onCancel();
   }
 
   protected closeMenu(event: Event): void {

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.ts
@@ -92,6 +92,12 @@ export class ProjectSectionComponent {
     this.menuOpen.update(v => !v);
   }
 
+  protected onSectionNameClick(event: Event): void {
+    if (this.editing()) return;
+
+    this.onEdit(event);
+  }
+
   protected closeMenu(event: Event): void {
     event.stopPropagation();
     this.menuOpen.set(false);


### PR DESCRIPTION
This solves issue #108 .

This pull request enhances the user interaction for editing project section names by making the section name input clickable and starting the editing mode on click. It also updates the cursor style to indicate interactivity and adds a corresponding unit test to ensure the new behavior works as expected.

User interaction improvements:

* The section name input in `project-section.component.html` now triggers editing mode when clicked by calling the new `onSectionNameClick` handler. 
* The CSS for the section name input updates the cursor to `pointer`, visually indicating that the input is clickable.

Testing:

* Adds a unit test to verify that clicking the section name input starts editing mode and updates the component state accordingly.

---
Before:


https://github.com/user-attachments/assets/b0ed2e0a-d4f8-4c5f-ae62-0789dd36ba8d


After:

https://github.com/user-attachments/assets/14423d95-07a2-449a-8bc3-c5e95fd0a246



