### PR TITLE
Feat/task edit logic

### DIFF
--- a/src/app/features/projects/application/use-cases/tasks/create-task/create-task.use-case.ts
+++ b/src/app/features/projects/application/use-cases/tasks/create-task/create-task.use-case.ts
@@ -16,7 +16,7 @@ export class CreateTaskUseCase {
     projectId: string,
     sectionId: string,
     taskName: string,
-    startDate: Date = new Date(),
+    startDate?: Date,
   ): Observable<Result<Task, ProjectsError>> {
     const taskNameResult = TaskName.tryCreate(taskName);
     if (!taskNameResult.success) {

--- a/src/app/features/projects/domain/entities/task.entity.spec.ts
+++ b/src/app/features/projects/domain/entities/task.entity.spec.ts
@@ -30,4 +30,20 @@ describe('Task', () => {
     expect(next.name).toBe('Renamed');
     expect(base.name).toBe('Write docs');
   });
+
+  it('setStartDate sets provided date and supports clearing', () => {
+    const newStart = new Date('2025-07-01');
+    const withStart = base.setStartDate(newStart);
+    const withoutStart = withStart.setStartDate(undefined);
+
+    expect(withStart.startDate).toEqual(newStart);
+    expect(withoutStart.startDate).toBeUndefined();
+  });
+
+  it('setEndDate supports clearing end date', () => {
+    const withEndDate = base.setEndDate(new Date('2025-07-15'));
+    const withoutEndDate = withEndDate.setEndDate(undefined);
+
+    expect(withoutEndDate.endDate).toBeUndefined();
+  });
 });

--- a/src/app/features/projects/domain/entities/task.entity.ts
+++ b/src/app/features/projects/domain/entities/task.entity.ts
@@ -4,7 +4,7 @@ export class Task {
     public readonly sectionId: string,
     public readonly name: string,
     public readonly completed: boolean,
-    public readonly startDate: Date,
+    public readonly startDate: Date | undefined,
     public readonly description?: string,
     public readonly label?: string,
     public readonly endDate?: Date,
@@ -16,7 +16,7 @@ export class Task {
   static create(
     name: string,
     sectionId: string,
-    startDate: Date = new Date(),
+    startDate?: Date,
     id?: string,
     parentTaskId?: string
   ): Task {
@@ -98,6 +98,22 @@ export class Task {
     );
   }
 
+  setStartDate(startDate: Date | undefined): Task {
+    return new Task(
+      this.id,
+      this.sectionId,
+      this.name,
+      this.completed,
+      startDate,
+      this.description,
+      this.label,
+      this.endDate,
+      this.completedDate,
+      this.parentTaskId,
+      this.subtaskIds,
+    );
+  }
+
   setLabel(label: string): Task {
     return new Task(
       this.id,
@@ -114,7 +130,7 @@ export class Task {
     );
   }
 
-  setEndDate(endDate: Date): Task {
+  setEndDate(endDate: Date | undefined): Task {
     return new Task(
       this.id,
       this.sectionId,

--- a/src/app/features/projects/infrastructure/dto/task.dto.ts
+++ b/src/app/features/projects/infrastructure/dto/task.dto.ts
@@ -2,10 +2,14 @@ export interface TaskDto {
   id: number;
   name: string;
   description: string;
-  start_date: Date;
-  end_date: Date;
+  start_date?: Date | string | null;
+  end_date?: Date | string | null;
+  startDate?: Date | string | null;
+  endDate?: Date | string | null;
+  completedDate?: Date | string | null;
   completed: boolean;
   label?: string;
   parent_task_id?: number;
+  sectionId?: number | string;
   subtasks?: TaskDto[];
 }

--- a/src/app/features/projects/infrastructure/dto/update-task.dto.ts
+++ b/src/app/features/projects/infrastructure/dto/update-task.dto.ts
@@ -1,0 +1,8 @@
+export interface UpdateTaskDto {
+  name: string;
+  description?: string;
+  startDate?: string;
+  endDate?: string;
+  completed?: boolean;
+  label?: string;
+}

--- a/src/app/features/projects/infrastructure/mappers/task.mapper.spec.ts
+++ b/src/app/features/projects/infrastructure/mappers/task.mapper.spec.ts
@@ -34,6 +34,24 @@ describe('TaskMapper', () => {
     expect(t.subtaskIds).toEqual(['2']);
   });
 
+  it('toDomain maps camelCase date fields from API response', () => {
+    const t = TaskMapper.toDomain(
+      {
+        id: 14,
+        name: 'Task 2',
+        description: '',
+        startDate: '2026-04-29',
+        endDate: '2026-05-08',
+        completed: false,
+        subtasks: [],
+      },
+      '36',
+    );
+
+    expect(t.startDate).toEqual(new Date('2026-04-29'));
+    expect(t.endDate).toEqual(new Date('2026-05-08'));
+  });
+
   it('flattenToDomain returns parent and nested tasks', () => {
     const flat = TaskMapper.flattenToDomain(dto, 'sec-1');
     expect(flat.map((x) => x.id)).toContain('1');
@@ -51,5 +69,19 @@ describe('TaskMapper', () => {
     expect(create.start_date).toEqual(start);
     expect(create.end_date).toEqual(end);
     expect(create.completed).toBe(false);
+  });
+
+  it('toDto maps update payload using camelCase date fields', () => {
+    const task = TaskMapper.toDomain(
+      { id: 1, name: 'N', description: 'd', start_date: start, end_date: end, completed: false },
+      's',
+    );
+
+    const update = TaskMapper.toDto(task);
+    expect(update.name).toBe('N');
+    expect(update.description).toBe('d');
+    expect(update.startDate).toBe('2025-03-01');
+    expect(update.endDate).toBe('2025-03-31');
+    expect(update.completed).toBe(false);
   });
 });

--- a/src/app/features/projects/infrastructure/mappers/task.mapper.ts
+++ b/src/app/features/projects/infrastructure/mappers/task.mapper.ts
@@ -1,6 +1,8 @@
 import { Task } from '@features/projects/domain/entities/task.entity';
 import { TaskDto } from '@features/projects/infrastructure/dto/task.dto';
 import { CreateTaskDto } from '@features/projects/infrastructure/dto/create-task.dto';
+import { UpdateTaskDto } from '@features/projects/infrastructure/dto/update-task.dto';
+import { formatDateToISO } from '@shared/utils/date.util';
 
 export class TaskMapper {
   /**
@@ -9,15 +11,17 @@ export class TaskMapper {
    */
   static toDomain(dto: TaskDto, sectionId: string, parentTaskId?: string): Task {
     const subtaskIds = (dto.subtasks ?? []).map(s => String(s.id));
+    const startDate = TaskMapper.parseDate(dto.startDate ?? dto.start_date);
+    const endDate = TaskMapper.parseDate(dto.endDate ?? dto.end_date);
     return new Task(
       String(dto.id),
       sectionId,
       dto.name,
       dto.completed,
-      dto.start_date,
+      startDate,
       dto.description,
       dto.label,
-      dto.end_date,
+      endDate,
       undefined,
       parentTaskId,
       subtaskIds,
@@ -48,14 +52,22 @@ export class TaskMapper {
     };
   }
 
-  static toDto(task: Task): Partial<TaskDto> {
+  static toDto(task: Task): UpdateTaskDto {
     return {
       name: task.name,
       description: task.description,
-      start_date: task.startDate,
-      end_date: task.endDate,
+      startDate: task.startDate ? formatDateToISO(task.startDate) : undefined,
+      endDate: task.endDate ? formatDateToISO(task.endDate) : undefined,
       completed: task.completed,
       label: task.label,
     };
+  }
+
+  private static parseDate(dateValue: Date | string | null | undefined): Date | undefined {
+    if (!dateValue) return undefined;
+    if (dateValue instanceof Date) return dateValue;
+
+    const parsed = new Date(dateValue);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed;
   }
 }

--- a/src/app/features/projects/infrastructure/repositories/http-task.repository.spec.ts
+++ b/src/app/features/projects/infrastructure/repositories/http-task.repository.spec.ts
@@ -47,6 +47,14 @@ describe('HttpTaskRepository', () => {
     repository.update('p1', task).subscribe();
     const req = httpMock.expectOne('/projects/p1/section/sec/task/t1/update');
     expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual({
+      name: 'Job',
+      description: undefined,
+      startDate: '2025-01-01',
+      endDate: '2025-01-02',
+      completed: true,
+      label: undefined,
+    });
     req.flush({
       id: 1,
       name: 'Job',

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.html
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.html
@@ -78,6 +78,7 @@
                     (taskToggle)="onTaskToggle($event)"
                     (taskRename)="onTaskRename($event)"
                     (taskDelete)="onTaskDelete($event)"
+                    (taskEdit)="onTaskEdit($event)"
                 />
             }
 

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/project-section.component.ts
@@ -8,6 +8,7 @@ import {
   SectionViewModel,
   TaskCreateEvent,
   TaskDeleteEvent,
+  TaskEditEvent,
   TaskRenameEvent,
   TaskToggleEvent,
 } from '@features/projects/presentation/models/project.view-model';
@@ -32,6 +33,7 @@ export class ProjectSectionComponent {
   public taskCreate = output<TaskCreateEvent>();
   public taskRename = output<TaskRenameEvent>();
   public taskDelete = output<TaskDeleteEvent>();
+  public taskEdit = output<TaskEditEvent>();
   public sectionUpdate = output<SectionUpdateEvent>();
   public sectionDelete = output<SectionDeleteEvent>();
 
@@ -199,5 +201,9 @@ export class ProjectSectionComponent {
 
   protected onTaskDelete(event: TaskDeleteEvent): void {
     this.taskDelete.emit(event);
+  }
+
+  protected onTaskEdit(event: TaskEditEvent): void {
+    this.taskEdit.emit(event);
   }
 }

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task-edit-modal/task-edit-modal.component.css
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task-edit-modal/task-edit-modal.component.css
@@ -11,6 +11,7 @@
   --focus-ring-color: rgb(0 123 255 / 12%);
   --contrast-white-color: #fff;
   --action-save-bg-color: #222;
+  --error-color: #d33;
 
   .task-edit-modal {
     padding: var(--modal-content-padding, 1.25rem 1.5rem);
@@ -157,6 +158,11 @@
         border-color: var(--focus-blue-color);
         outline: none;
         box-shadow: 0 0 0 3px var(--focus-ring-color);
+      }
+
+      .field-error {
+        font-size: 11px;
+        color: var(--error-color);
       }
     }
 

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task-edit-modal/task-edit-modal.component.css
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task-edit-modal/task-edit-modal.component.css
@@ -164,6 +164,17 @@
         font-size: 11px;
         color: var(--error-color);
       }
+
+      .clear-date-button {
+        align-self: flex-start;
+        border: none;
+        background: transparent;
+        color: var(--focus-blue-color);
+        font-size: 11px;
+        padding: 0;
+        cursor: pointer;
+        text-decoration: underline;
+      }
     }
 
     .date-grid {

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task-edit-modal/task-edit-modal.component.html
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task-edit-modal/task-edit-modal.component.html
@@ -44,7 +44,10 @@
     <div class="date-grid">
       <div class="form-group">
         <label for="startDate">Start date</label>
-        <input id="startDate" type="date" formControlName="startDate" />
+        <input id="startDate" type="date" formControlName="startDate" [min]="todayDateInput" />
+        @if (taskForm.controls.startDate.touched && startDateError) {
+          <span class="field-error">{{ startDateError }}</span>
+        }
       </div>
 
       <div class="form-group">

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task-edit-modal/task-edit-modal.component.html
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task-edit-modal/task-edit-modal.component.html
@@ -45,6 +45,7 @@
       <div class="form-group">
         <label for="startDate">Start date</label>
         <input id="startDate" type="date" formControlName="startDate" [min]="todayDateInput" />
+        <button id="clearStartDate" type="button" class="clear-date-button" (click)="clearStartDate()">Clear start date</button>
         @if (taskForm.controls.startDate.touched && startDateError) {
           <span class="field-error">{{ startDateError }}</span>
         }
@@ -53,6 +54,7 @@
       <div class="form-group">
         <label for="endDate">End date</label>
         <input id="endDate" type="date" formControlName="endDate" />
+        <button id="clearEndDate" type="button" class="clear-date-button" (click)="clearEndDate()">Clear end date</button>
       </div>
     </div>
 

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task-edit-modal/task-edit-modal.component.html
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task-edit-modal/task-edit-modal.component.html
@@ -53,8 +53,11 @@
 
       <div class="form-group">
         <label for="endDate">End date</label>
-        <input id="endDate" type="date" formControlName="endDate" />
+        <input id="endDate" type="date" formControlName="endDate" [min]="taskForm.controls.startDate.value || undefined" />
         <button id="clearEndDate" type="button" class="clear-date-button" (click)="clearEndDate()">Clear end date</button>
+        @if ((taskForm.controls.endDate.touched || taskForm.controls.startDate.touched) && endDateError) {
+          <span class="field-error">{{ endDateError }}</span>
+        }
       </div>
     </div>
 

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task-edit-modal/task-edit-modal.component.spec.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task-edit-modal/task-edit-modal.component.spec.ts
@@ -48,4 +48,26 @@ describe('TaskEditModalComponent', () => {
     form.dispatchEvent(new Event('submit'));
     expect(modalRef.close).toHaveBeenCalled();
   });
+
+  it('does not close the modal when start date is before today', () => {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    const year = yesterday.getFullYear();
+    const month = `${yesterday.getMonth() + 1}`.padStart(2, '0');
+    const day = `${yesterday.getDate()}`.padStart(2, '0');
+    const yesterdayInputValue = `${year}-${month}-${day}`;
+
+    const startDateInput: HTMLInputElement = fixture.nativeElement.querySelector('#startDate');
+    startDateInput.value = yesterdayInputValue;
+    startDateInput.dispatchEvent(new Event('input'));
+    startDateInput.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    const form: HTMLFormElement = fixture.nativeElement.querySelector('form');
+    form.dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+
+    expect(modalRef.close).not.toHaveBeenCalled();
+    expect(fixture.nativeElement.textContent).toContain('Start date cannot be before today');
+  });
 });

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task-edit-modal/task-edit-modal.component.spec.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task-edit-modal/task-edit-modal.component.spec.ts
@@ -104,4 +104,25 @@ describe('TaskEditModalComponent', () => {
 
     expect(endDateInput.value).toBe('');
   });
+
+  it('does not close when end date is before start date', () => {
+    const startDateInput: HTMLInputElement = fixture.nativeElement.querySelector('#startDate');
+    const endDateInput: HTMLInputElement = fixture.nativeElement.querySelector('#endDate');
+
+    startDateInput.value = '2099-01-10';
+    startDateInput.dispatchEvent(new Event('input'));
+    startDateInput.dispatchEvent(new Event('change'));
+
+    endDateInput.value = '2099-01-01';
+    endDateInput.dispatchEvent(new Event('input'));
+    endDateInput.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    const form: HTMLFormElement = fixture.nativeElement.querySelector('form');
+    form.dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+
+    expect(modalRef.close).not.toHaveBeenCalled();
+    expect(fixture.nativeElement.textContent).toContain('End date cannot be before start date');
+  });
 });

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task-edit-modal/task-edit-modal.component.spec.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task-edit-modal/task-edit-modal.component.spec.ts
@@ -46,7 +46,11 @@ describe('TaskEditModalComponent', () => {
   it('closes the modal when save is submitted', () => {
     const form: HTMLFormElement = fixture.nativeElement.querySelector('form');
     form.dispatchEvent(new Event('submit'));
-    expect(modalRef.close).toHaveBeenCalled();
+    expect(modalRef.close).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'Write release notes',
+      description: 'Details',
+      completed: false,
+    }));
   });
 
   it('does not close the modal when start date is before today', () => {

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task-edit-modal/task-edit-modal.component.spec.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task-edit-modal/task-edit-modal.component.spec.ts
@@ -70,4 +70,34 @@ describe('TaskEditModalComponent', () => {
     expect(modalRef.close).not.toHaveBeenCalled();
     expect(fixture.nativeElement.textContent).toContain('Start date cannot be before today');
   });
+
+  it('allows saving after clearing start date', () => {
+    const startDateInput: HTMLInputElement = fixture.nativeElement.querySelector('#startDate');
+    const clearStartDateButton: HTMLButtonElement = fixture.nativeElement.querySelector('#clearStartDate');
+
+    clearStartDateButton.click();
+    fixture.detectChanges();
+
+    expect(startDateInput.value).toBe('');
+
+    const form: HTMLFormElement = fixture.nativeElement.querySelector('form');
+    form.dispatchEvent(new Event('submit'));
+
+    expect(modalRef.close).toHaveBeenCalled();
+  });
+
+  it('clears end date when clear end date is clicked', () => {
+    const endDateInput: HTMLInputElement = fixture.nativeElement.querySelector('#endDate');
+    const clearEndDateButton: HTMLButtonElement = fixture.nativeElement.querySelector('#clearEndDate');
+
+    endDateInput.value = '2099-01-01';
+    endDateInput.dispatchEvent(new Event('input'));
+    endDateInput.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    clearEndDateButton.click();
+    fixture.detectChanges();
+
+    expect(endDateInput.value).toBe('');
+  });
 });

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task-edit-modal/task-edit-modal.component.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task-edit-modal/task-edit-modal.component.ts
@@ -35,7 +35,7 @@ export class TaskEditModalComponent {
     endDate: new FormControl(this.toDateInputValue(this.modalData?.endDate), {
       nonNullable: true,
     }),
-  });
+  }, { validators: [this.endDateAfterStartDateValidator()] });
 
   protected get nameError(): string | null {
     const errors = this.taskForm.controls.name.errors;
@@ -54,6 +54,13 @@ export class TaskEditModalComponent {
     const errors = this.taskForm.controls.startDate.errors;
     if (!errors) return null;
     if (errors['minToday']) return 'Start date cannot be before today';
+    return null;
+  }
+
+  protected get endDateError(): string | null {
+    if (this.taskForm.hasError('endBeforeStartDate')) {
+      return 'End date cannot be before start date';
+    }
     return null;
   }
 
@@ -111,6 +118,25 @@ export class TaskEditModalComponent {
       if (Number.isNaN(selectedDate.getTime())) return null;
 
       return selectedDate < today ? { minToday: true } : null;
+    };
+  }
+
+  private endDateAfterStartDateValidator(): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const group = control as FormGroup<{
+        startDate: FormControl<string>;
+        endDate: FormControl<string>;
+      }>;
+
+      const startValue = group.controls.startDate.value;
+      const endValue = group.controls.endDate.value;
+      if (!startValue || !endValue) return null;
+
+      const startDate = new Date(`${startValue}T00:00:00`);
+      const endDate = new Date(`${endValue}T00:00:00`);
+      if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) return null;
+
+      return endDate < startDate ? { endBeforeStartDate: true } : null;
     };
   }
 }

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task-edit-modal/task-edit-modal.component.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task-edit-modal/task-edit-modal.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
-import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { AbstractControl, FormControl, FormGroup, ReactiveFormsModule, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
 import { AutoFocusDirective } from '@shared/directives/auto-focus.directive';
 import { MODAL_DATA, ModalRef } from '@shared/ui/modal/modal-ref';
 import { TaskEditModalState } from '@features/projects/presentation/models/task-edit-modal.state';
@@ -17,6 +17,7 @@ export class TaskEditModalComponent {
   private readonly modalData = inject<TaskEditModalState | null>(MODAL_DATA, { optional: true });
 
   protected readonly completed = signal(this.modalData?.completed ?? false);
+  protected readonly todayDateInput = this.toDateInputValue(new Date());
 
   protected readonly taskForm = new FormGroup({
     name: new FormControl(this.modalData?.name ?? '', {
@@ -29,7 +30,7 @@ export class TaskEditModalComponent {
     }),
     startDate: new FormControl(this.toDateInputValue(this.modalData?.startDate), {
       nonNullable: true,
-      validators: [Validators.required],
+      validators: [Validators.required, this.minTodayDateValidator()],
     }),
     endDate: new FormControl(this.toDateInputValue(this.modalData?.endDate), {
       nonNullable: true,
@@ -47,6 +48,14 @@ export class TaskEditModalComponent {
 
   protected toggleCompletion(): void {
     this.completed.update((v) => !v);
+  }
+
+  protected get startDateError(): string | null {
+    const errors = this.taskForm.controls.startDate.errors;
+    if (!errors) return null;
+    if (errors['required']) return 'Start date is required';
+    if (errors['minToday']) return 'Start date cannot be before today';
+    return null;
   }
 
   protected save(): void {
@@ -70,5 +79,20 @@ export class TaskEditModalComponent {
     const day = `${date.getDate()}`.padStart(2, '0');
 
     return `${year}-${month}-${day}`;
+  }
+
+  private minTodayDateValidator(): ValidatorFn {
+    return (control: AbstractControl<string>): ValidationErrors | null => {
+      const value = control.value;
+      if (!value) return null;
+
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+
+      const selectedDate = new Date(`${value}T00:00:00`);
+      if (Number.isNaN(selectedDate.getTime())) return null;
+
+      return selectedDate < today ? { minToday: true } : null;
+    };
   }
 }

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task-edit-modal/task-edit-modal.component.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task-edit-modal/task-edit-modal.component.ts
@@ -30,7 +30,7 @@ export class TaskEditModalComponent {
     }),
     startDate: new FormControl(this.toDateInputValue(this.modalData?.startDate), {
       nonNullable: true,
-      validators: [Validators.required, this.minTodayDateValidator()],
+      validators: [this.minTodayDateValidator()],
     }),
     endDate: new FormControl(this.toDateInputValue(this.modalData?.endDate), {
       nonNullable: true,
@@ -53,9 +53,20 @@ export class TaskEditModalComponent {
   protected get startDateError(): string | null {
     const errors = this.taskForm.controls.startDate.errors;
     if (!errors) return null;
-    if (errors['required']) return 'Start date is required';
     if (errors['minToday']) return 'Start date cannot be before today';
     return null;
+  }
+
+  protected clearStartDate(): void {
+    this.taskForm.controls.startDate.setValue('');
+    this.taskForm.controls.startDate.markAsTouched();
+    this.taskForm.controls.startDate.updateValueAndValidity();
+  }
+
+  protected clearEndDate(): void {
+    this.taskForm.controls.endDate.setValue('');
+    this.taskForm.controls.endDate.markAsTouched();
+    this.taskForm.controls.endDate.updateValueAndValidity();
   }
 
   protected save(): void {

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task-edit-modal/task-edit-modal.component.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task-edit-modal/task-edit-modal.component.ts
@@ -75,7 +75,14 @@ export class TaskEditModalComponent {
       return;
     }
 
-    this.modalRef.close();
+    const { name, description, startDate, endDate } = this.taskForm.getRawValue();
+    this.modalRef.close({
+      name,
+      description,
+      startDate,
+      endDate,
+      completed: this.completed(),
+    });
   }
 
   protected cancel(): void {

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.html
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.html
@@ -22,9 +22,9 @@
                 class="task-name-input"
                 [class.invalid]="taskNameCtrl.touched && taskNameCtrl.invalid"
                 [formControl]="taskNameCtrl"
-                (keydown.enter)="onSave()"
-                (keydown.escape)="onCancel()"
-                (blur)="onSave()"
+                (keydown.enter)="onSave($event)"
+                (keydown.escape)="onCancel($event)"
+                (blur)="onSave($event)"
                 type="text"
             />
             @if (taskNameCtrl.touched && taskNameError) {

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.html
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.html
@@ -83,6 +83,7 @@
                 (taskToggle)="forwardTaskToggle($event)"
                 (taskRename)="forwardTaskRename($event)"
                 (taskDelete)="forwardTaskDelete($event)"
+                (taskEdit)="forwardTaskEdit($event)"
             />
         }
     </div>

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.ts
@@ -2,11 +2,13 @@ import { Component, forwardRef, input, output, signal, ChangeDetectionStrategy, 
 import { NgClass } from '@angular/common';
 import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import {
+  TaskEditEvent,
   TaskDeleteEvent,
   TaskRenameEvent,
   TaskToggleEvent,
   TaskViewModel,
 } from '@features/projects/presentation/models/project.view-model';
+import { TaskEditModalResult } from '@features/projects/presentation/models/task-edit-modal.state';
 import { AutoFocusDirective } from '@shared/directives/auto-focus.directive';
 import { ConfirmComponent } from '@shared/ui/modal/confirm/confirm.component';
 import { ModalService } from '@shared/ui/modal/modal.service';
@@ -28,6 +30,7 @@ export class TaskComponent {
   public taskToggle = output<TaskToggleEvent>();
   public taskRename = output<TaskRenameEvent>();
   public taskDelete = output<TaskDeleteEvent>();
+  public taskEdit = output<TaskEditEvent>();
 
   protected menuOpen = signal(false);
   protected editing = signal(false);
@@ -70,8 +73,31 @@ export class TaskComponent {
         id: this.taskInfo().id,
         name: this.taskInfo().name,
         completed: this.taskInfo().completed,
-        description: '', // FIXME: TaskViewModel should include description and endDate
+        description: this.taskInfo().description ?? '',
         startDate: this.taskInfo().startDate,
+        endDate: this.taskInfo().endDate,
+      },
+      onClose: (result?: unknown) => {
+        if (!result || typeof result !== 'object') return;
+
+        const modalResult = result as TaskEditModalResult;
+        const startDate = this.parseDateInputValue(modalResult.startDate);
+        const endDate = this.parseDateInputValue(modalResult.endDate);
+        const completedChanged = modalResult.completed !== this.taskInfo().completed;
+
+        this.taskEdit.emit({
+          id: this.taskInfo().id,
+          sectionId: this.sectionId(),
+          name: modalResult.name,
+          description: modalResult.description.trim() || undefined,
+          startDate,
+          endDate,
+          completedChanged,
+        });
+
+        if (completedChanged) {
+          this.taskToggle.emit({ id: this.taskInfo().id });
+        }
       },
     });
   }
@@ -148,5 +174,16 @@ export class TaskComponent {
 
   protected forwardTaskDelete(event: TaskDeleteEvent): void {
     this.taskDelete.emit(event);
+  }
+
+  protected forwardTaskEdit(event: TaskEditEvent): void {
+    this.taskEdit.emit(event);
+  }
+
+  private parseDateInputValue(value: string): Date | undefined {
+    if (!value) return undefined;
+
+    const parsed = new Date(`${value}T00:00:00`);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed;
   }
 }

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.ts
@@ -66,6 +66,8 @@ export class TaskComponent {
 
     if (this.editing()) return;
 
+    const initialCompleted = this.taskInfo().completed;
+
     this.menuOpen.set(false);
     this.modalService.open(TaskEditModalComponent, {
       title: 'Edit Task',
@@ -83,7 +85,7 @@ export class TaskComponent {
         const modalResult = result as TaskEditModalResult;
         const startDate = this.parseDateInputValue(modalResult.startDate);
         const endDate = this.parseDateInputValue(modalResult.endDate);
-        const completedChanged = modalResult.completed !== this.taskInfo().completed;
+        const completedChanged = modalResult.completed !== initialCompleted;
 
         this.taskEdit.emit({
           id: this.taskInfo().id,

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.ts
@@ -94,10 +94,6 @@ export class TaskComponent {
           endDate,
           completedChanged,
         });
-
-        if (completedChanged) {
-          this.taskToggle.emit({ id: this.taskInfo().id });
-        }
       },
     });
   }

--- a/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-section/task/task.component.ts
@@ -117,7 +117,12 @@ export class TaskComponent {
     this.editing.set(true);
   }
 
-  protected onSave(): void {
+  protected onSave(event?: Event): void {
+    event?.stopPropagation();
+    if (event instanceof KeyboardEvent) {
+      event.preventDefault();
+    }
+
     if (this.cancellingEdit) {
       this.cancellingEdit = false;
       return;
@@ -136,7 +141,12 @@ export class TaskComponent {
     this.editing.set(false);
   }
 
-  protected onCancel(): void {
+  protected onCancel(event?: Event): void {
+    event?.stopPropagation();
+    if (event instanceof KeyboardEvent) {
+      event.preventDefault();
+    }
+
     this.cancellingEdit = true;
     this.taskNameCtrl.markAsUntouched();
     this.editing.set(false);

--- a/src/app/features/projects/presentation/components/home/project-view/project-view.component.html
+++ b/src/app/features/projects/presentation/components/home/project-view/project-view.component.html
@@ -21,6 +21,7 @@
       (taskCreate)="onTaskCreate($event)"
       (taskRename)="onTaskRename($event)"
       (taskDelete)="onTaskDelete($event)"
+      (taskEdit)="onTaskEdit($event)"
       (sectionUpdate)="onSectionUpdate($event)"
       (sectionDelete)="onSectionDelete($event)"
     />

--- a/src/app/features/projects/presentation/components/home/project-view/project-view.component.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-view.component.ts
@@ -8,6 +8,7 @@ import {
   SectionUpdateEvent,
   TaskCreateEvent,
   TaskDeleteEvent,
+  TaskEditEvent,
   TaskRenameEvent,
   TaskToggleEvent,
 } from '@features/projects/presentation/models/project.view-model';
@@ -67,6 +68,13 @@ export class ProjectViewComponent {
 
   protected onTaskDelete(event: TaskDeleteEvent): void {
     this.projectStore.deleteTask(event.sectionId, event.id);
+  }
+
+  protected onTaskEdit(event: TaskEditEvent): void {
+    this.projectStore.editTask(event.id, event.name, event.description, event.startDate, event.endDate);
+    if (event.completedChanged) {
+      this.projectStore.toggleTaskCompletion(event.id);
+    }
   }
 
   protected onSectionUpdate(event: SectionUpdateEvent): void {

--- a/src/app/features/projects/presentation/models/project.view-model.ts
+++ b/src/app/features/projects/presentation/models/project.view-model.ts
@@ -39,10 +39,22 @@ export interface TaskDeleteEvent {
   sectionId: string;
 }
 
+export interface TaskEditEvent {
+  id: string;
+  sectionId: string;
+  name: string;
+  description?: string;
+  startDate?: Date;
+  endDate?: Date;
+  completedChanged: boolean;
+}
+
 export interface TaskViewModel {
   id: string;
   name: string;
   completed: boolean;
-  startDate: Date;
+  startDate: Date | undefined;
+  description?: string;
+  endDate?: Date;
   subtasks: TaskViewModel[];
 }

--- a/src/app/features/projects/presentation/models/task-edit-modal.state.ts
+++ b/src/app/features/projects/presentation/models/task-edit-modal.state.ts
@@ -6,3 +6,11 @@ export interface TaskEditModalState {
   startDate?: Date;
   endDate?: Date;
 }
+
+export interface TaskEditModalResult {
+  name: string;
+  description: string;
+  startDate: string;
+  endDate: string;
+  completed: boolean;
+}

--- a/src/app/features/projects/presentation/store/project.store.ts
+++ b/src/app/features/projects/presentation/store/project.store.ts
@@ -115,6 +115,8 @@ export class ProjectStore {
           name: task.name,
           completed: task.completed,
           startDate: task.startDate,
+          description: task.description,
+          endDate: task.endDate,
           subtasks: buildTaskTree(task.subtaskIds),
         }));
 
@@ -501,6 +503,17 @@ export class ProjectStore {
     }
 
     this.taskStore.updateTaskName(projectId, taskId, name);
+  }
+
+  /** Update task fields from edit modal */
+  editTask(taskId: string, name: string, description?: string, startDate?: Date, endDate?: Date): void {
+    const projectId = this.state().selectedProjectId;
+    if (!projectId) {
+      console.error('Cannot edit task: no project selected');
+      return;
+    }
+
+    this.taskStore.editTask(projectId, taskId, name, description, startDate, endDate);
   }
 
   /** Delete a task from section */

--- a/src/app/features/projects/presentation/store/task.store.spec.ts
+++ b/src/app/features/projects/presentation/store/task.store.spec.ts
@@ -101,6 +101,50 @@ describe('TaskStore', () => {
     expect(store.tasks()['t1']?.name).toBe('New Name');
   });
 
+  it('editTask updates multiple fields when use case succeeds', () => {
+    const start = new Date('2026-01-01');
+    const end = new Date('2026-01-02');
+    const t = new Task('t1', 's1', 'Old Name', false, start, 'Old description', undefined, end, undefined, undefined, []);
+    store.mergeTasks([t]);
+
+    const nextStart = new Date('2026-01-10');
+    const nextEnd = new Date('2026-01-20');
+    store.editTask('p1', 't1', 'New Name', 'New description', nextStart, nextEnd);
+
+    expect(updateExecute).toHaveBeenCalled();
+    expect(store.tasks()['t1']?.name).toBe('New Name');
+    expect(store.tasks()['t1']?.description).toBe('New description');
+    expect(store.tasks()['t1']?.startDate).toEqual(nextStart);
+    expect(store.tasks()['t1']?.endDate).toEqual(nextEnd);
+  });
+
+  it('editTask rolls back optimistic update when use case fails', () => {
+    const start = new Date('2026-01-01');
+    const t = new Task('t1', 's1', 'Old Name', false, start, 'Old description', undefined, undefined, undefined, undefined, []);
+    store.mergeTasks([t]);
+    updateExecute.mockReturnValue(of({ success: false, error: { code: 'NETWORK_ERROR' as const } }));
+
+    store.editTask('p1', 't1', 'New Name', 'New description', undefined, undefined);
+
+    expect(updateExecute).toHaveBeenCalled();
+    expect(store.tasks()['t1']?.name).toBe('Old Name');
+    expect(store.tasks()['t1']?.description).toBe('Old description');
+    expect(store.tasks()['t1']?.startDate).toEqual(start);
+  });
+
+  it('editTask rolls back optimistic update when validation fails', () => {
+    const start = new Date('2026-01-01');
+    const t = new Task('t1', 's1', 'Old Name', false, start, 'Old description', undefined, undefined, undefined, undefined, []);
+    store.mergeTasks([t]);
+    updateExecute.mockReturnValue(of({ success: false, error: { code: 'TASK_NAME_REQUIRED' as const } }));
+
+    store.editTask('p1', 't1', '', 'New description', undefined, undefined);
+
+    expect(updateExecute).toHaveBeenCalled();
+    expect(store.tasks()['t1']?.name).toBe('Old Name');
+    expect(store.tasks()['t1']?.description).toBe('Old description');
+  });
+
   it('deleteTask removes task and descendants on success', () => {
     const child = new Task('c1', 's1', 'Child', false, new Date(), undefined, undefined, undefined, undefined, 'p1', []);
     const parent = new Task('p1', 's1', 'Parent', false, new Date(), undefined, undefined, undefined, undefined, undefined, ['c1']);

--- a/src/app/features/projects/presentation/store/task.store.ts
+++ b/src/app/features/projects/presentation/store/task.store.ts
@@ -184,15 +184,55 @@ export class TaskStore {
     const existing = this.state().tasks[taskId];
     if (!existing) return;
 
-    const updatedName = newName.trim();
-    if (!updatedName || updatedName === existing.name) return;
+    this.editTask(
+      projectId,
+      taskId,
+      newName,
+      existing.description,
+      existing.startDate,
+      existing.endDate,
+    );
+  }
 
-    const requestTask = existing.updateName(updatedName);
+  /** Update a task's editable fields in backend and local state */
+  editTask(
+    projectId: string,
+    taskId: string,
+    name: string,
+    description?: string,
+    startDate?: Date,
+    endDate?: Date,
+  ): void {
+    const existing = this.state().tasks[taskId];
+    if (!existing) return;
 
-    this.updateTaskUseCase.execute(projectId, requestTask).subscribe({
+    const updatedName = name.trim();
+    const normalizedDescription = description?.trim() ? description.trim() : undefined;
+    const nextTask = existing
+      .updateName(updatedName)
+      .updateDescription(normalizedDescription ?? '')
+      .setStartDate(startDate)
+      .setEndDate(endDate);
+
+    const hasChanges = nextTask.name !== existing.name
+      || nextTask.description !== existing.description
+      || nextTask.startDate?.getTime() !== existing.startDate?.getTime()
+      || nextTask.endDate?.getTime() !== existing.endDate?.getTime();
+    if (!hasChanges) return;
+
+    this.state.update(s => ({
+      ...s,
+      tasks: { ...s.tasks, [taskId]: nextTask },
+    }));
+
+    this.updateTaskUseCase.execute(projectId, nextTask).subscribe({
       next: (result) => {
         if (!result.success) {
-          this.setResultError(result.error, 'update task name');
+          this.state.update(s => ({
+            ...s,
+            tasks: { ...s.tasks, [taskId]: existing },
+          }));
+          this.setResultError(result.error, 'update task');
           return;
         }
 
@@ -201,7 +241,7 @@ export class TaskStore {
           ...s,
           tasks: {
             ...s.tasks,
-            [taskId]: requestTask.updateName(updatedTask.name),
+            [taskId]: updatedTask,
           },
         }));
       },


### PR DESCRIPTION
I basically added the functionality for actually editing the task from the design accepted in the PR #110 .

I also added some missing form validation as well.

New UI changes:

https://github.com/user-attachments/assets/46496f30-ec88-47c6-b11c-6d659c64b3a2

---

AI Summary:
This pull request introduces enhancements to task editing functionality, particularly around date handling, and improves the event flow for editing tasks. The main changes include allowing start and end dates to be unset, adding validation to prevent setting a start date before today, and ensuring the UI and events support these features. Several tests and UI improvements are also included to ensure correct behavior and user feedback.

**Task entity and date handling improvements:**

* The `Task` entity now allows `startDate` to be `undefined`, and both `setStartDate` and `setEndDate` methods support clearing their respective dates. This enables tasks to have optional start and end dates. 
* Unit tests for the `Task` entity verify that start and end dates can be set and cleared as expected.

**Task editing modal enhancements:**

* The task edit modal now includes "Clear" buttons for start and end dates, and displays an error if the start date is set before today. The start date input is also restricted to not allow dates before today.
* Unit tests for the modal verify that clearing dates works, and that saving is blocked if the start date is before today.

**Event and component wiring for editing tasks:**

* Added a new `taskEdit` event and corresponding handlers throughout the `TaskComponent`, `ProjectSectionComponent`, and `ProjectViewComponent`, ensuring that edits (including date changes) are properly emitted and handled in the component hierarchy. 

These changes collectively make task date management more flexible and user-friendly, and ensure that the editing workflow is robust and well-tested.