### PR TITLE
Refactor/task updates

### DIFF
--- a/src/app/features/projects/infrastructure/dto/update-task.dto.ts
+++ b/src/app/features/projects/infrastructure/dto/update-task.dto.ts
@@ -3,6 +3,7 @@ export interface UpdateTaskDto {
   description?: string;
   startDate?: string;
   endDate?: string;
-  completed?: boolean;
+  /** Set when marking complete via task update (e.g. edit modal); omit otherwise. Backend infers completion from this. */
+  completedDate?: string;
   label?: string;
 }

--- a/src/app/features/projects/infrastructure/mappers/task.mapper.spec.ts
+++ b/src/app/features/projects/infrastructure/mappers/task.mapper.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
 import { TaskMapper } from './task.mapper';
+import { formatDateToISO } from '@shared/utils/date.util';
 import { TaskDto } from '@features/projects/infrastructure/dto/task.dto';
 
 describe('TaskMapper', () => {
@@ -82,6 +83,16 @@ describe('TaskMapper', () => {
     expect(update.description).toBe('d');
     expect(update.startDate).toBe('2025-03-01');
     expect(update.endDate).toBe('2025-03-31');
-    expect(update.completed).toBe(false);
+    expect(update.completedDate).toBeUndefined();
+  });
+
+  it('toDto includes completedDate when task is completed with a completion timestamp', () => {
+    const done = TaskMapper.toDomain(
+      { id: 1, name: 'N', description: 'd', start_date: start, end_date: end, completed: false },
+      's',
+    ).complete();
+
+    const update = TaskMapper.toDto(done);
+    expect(update.completedDate).toBe(formatDateToISO(done.completedDate!));
   });
 });

--- a/src/app/features/projects/infrastructure/mappers/task.mapper.ts
+++ b/src/app/features/projects/infrastructure/mappers/task.mapper.ts
@@ -53,12 +53,15 @@ export class TaskMapper {
   }
 
   static toDto(task: Task): UpdateTaskDto {
+    const completedDate =
+      task.completed && task.completedDate ? formatDateToISO(task.completedDate) : undefined;
+
     return {
       name: task.name,
       description: task.description,
       startDate: task.startDate ? formatDateToISO(task.startDate) : undefined,
       endDate: task.endDate ? formatDateToISO(task.endDate) : undefined,
-      completed: task.completed,
+      ...(completedDate !== undefined ? { completedDate } : {}),
       label: task.label,
     };
   }

--- a/src/app/features/projects/infrastructure/repositories/http-task.repository.spec.ts
+++ b/src/app/features/projects/infrastructure/repositories/http-task.repository.spec.ts
@@ -43,7 +43,8 @@ describe('HttpTaskRepository', () => {
   });
 
   it('update PUTs to task update URL', () => {
-    const task = new Task('t1', 'sec', 'Job', true, start, undefined, undefined, end, undefined, undefined, []);
+    const completedAt = new Date('2026-05-02');
+    const task = new Task('t1', 'sec', 'Job', true, start, undefined, undefined, end, completedAt, undefined, []);
     repository.update('p1', task).subscribe();
     const req = httpMock.expectOne('/projects/p1/section/sec/task/t1/update');
     expect(req.request.method).toBe('PUT');
@@ -52,7 +53,7 @@ describe('HttpTaskRepository', () => {
       description: undefined,
       startDate: '2025-01-01',
       endDate: '2025-01-02',
-      completed: true,
+      completedDate: '2026-05-02',
       label: undefined,
     });
     req.flush({

--- a/src/app/features/projects/presentation/components/home/project-view/project-view.component.ts
+++ b/src/app/features/projects/presentation/components/home/project-view/project-view.component.ts
@@ -71,10 +71,14 @@ export class ProjectViewComponent {
   }
 
   protected onTaskEdit(event: TaskEditEvent): void {
-    this.projectStore.editTask(event.id, event.name, event.description, event.startDate, event.endDate);
-    if (event.completedChanged) {
-      this.projectStore.toggleTaskCompletion(event.id);
-    }
+    this.projectStore.editTask(
+      event.id,
+      event.name,
+      event.description,
+      event.startDate,
+      event.endDate,
+      event.completedChanged,
+    );
   }
 
   protected onSectionUpdate(event: SectionUpdateEvent): void {

--- a/src/app/features/projects/presentation/store/project.store.ts
+++ b/src/app/features/projects/presentation/store/project.store.ts
@@ -506,14 +506,21 @@ export class ProjectStore {
   }
 
   /** Update task fields from edit modal */
-  editTask(taskId: string, name: string, description?: string, startDate?: Date, endDate?: Date): void {
+  editTask(
+    taskId: string,
+    name: string,
+    description?: string,
+    startDate?: Date,
+    endDate?: Date,
+    completionChanged?: boolean,
+  ): void {
     const projectId = this.state().selectedProjectId;
     if (!projectId) {
       console.error('Cannot edit task: no project selected');
       return;
     }
 
-    this.taskStore.editTask(projectId, taskId, name, description, startDate, endDate);
+    this.taskStore.editTask(projectId, taskId, name, description, startDate, endDate, completionChanged);
   }
 
   /** Delete a task from section */

--- a/src/app/features/projects/presentation/store/task.store.spec.ts
+++ b/src/app/features/projects/presentation/store/task.store.spec.ts
@@ -39,6 +39,55 @@ describe('TaskStore', () => {
     store = TestBed.inject(TaskStore);
   });
 
+  it('mergeExternalTask inserts task when absent', () => {
+    const t = new Task('t-new', 's1', 'Remote', false, new Date(), undefined, undefined, undefined, undefined, undefined, []);
+    store.mergeExternalTask(t);
+    expect(store.tasks()['t-new']?.name).toBe('Remote');
+  });
+
+  it('rollbackExternalTaskMerge removes task that was absent before optimistic mergeExternalTask', () => {
+    const t = new Task('ghost', 's', 'Ghost', false, new Date(), undefined, undefined, undefined, undefined, undefined, []);
+    store.mergeExternalTask(t);
+    expect(store.tasks()['ghost']).toBeDefined();
+    store.rollbackExternalTaskMerge('ghost', undefined);
+    expect(store.tasks()['ghost']).toBeUndefined();
+  });
+
+  it('rollbackExternalTaskMerge restores prior row after failed optimistic merge', () => {
+    const start = new Date('2026-03-01');
+    const prior = new Task('t1', 's1', 'Old', false, start, undefined, undefined, undefined, undefined, undefined, []);
+    store.mergeTasks([prior]);
+    const optimistic = prior.updateName('New');
+    store.mergeExternalTask(optimistic);
+    expect(store.tasks()['t1']?.name).toBe('New');
+    store.rollbackExternalTaskMerge('t1', prior);
+    expect(store.tasks()['t1']?.name).toBe('Old');
+  });
+
+  it('rollbackOptimisticDelete restores deleted subtree and parent subtask ids', () => {
+    const child = new Task('c1', 's1', 'Child', false, new Date(), undefined, undefined, undefined, undefined, 'p1', []);
+    const parent = new Task('p1', 's1', 'Parent', false, new Date(), undefined, undefined, undefined, undefined, undefined, ['c1']);
+    store.mergeTasks([parent, child]);
+    const snap = store.snapshotForOptimisticDelete('c1');
+    expect(snap).not.toBeNull();
+    store.removeTask('c1');
+    expect(store.tasks()['c1']).toBeUndefined();
+    expect(store.tasks()['p1']?.subtaskIds).not.toContain('c1');
+    store.rollbackOptimisticDelete(snap!);
+    expect(store.tasks()['c1']?.name).toBe('Child');
+    expect(store.tasks()['p1']?.subtaskIds).toContain('c1');
+  });
+
+  it('mergeExternalTask preserves subtasks when syncing a flat snapshot', () => {
+    const child = new Task('c1', 's1', 'Child', false, new Date(), undefined, undefined, undefined, undefined, 'p1', []);
+    const parent = new Task('p1', 's1', 'Parent', false, new Date(), undefined, undefined, undefined, undefined, undefined, ['c1']);
+    store.mergeTasks([parent, child]);
+    const fromApi = new Task('p1', 's1', 'Parent', true, new Date(), undefined, undefined, undefined, new Date(), undefined, []);
+    store.mergeExternalTask(fromApi);
+    expect(store.tasks()['p1']?.completed).toBe(true);
+    expect(store.tasks()['p1']?.subtaskIds).toEqual(['c1']);
+  });
+
   it('mergeTasks adds tasks to dictionary', () => {
     const start = new Date();
     const t = new Task('t1', 's', 'Name', false, start, undefined, undefined, undefined, undefined, undefined, []);
@@ -99,6 +148,35 @@ describe('TaskStore', () => {
 
     expect(updateExecute).toHaveBeenCalled();
     expect(store.tasks()['t1']?.name).toBe('New Name');
+  });
+
+  it('editTask completes via update use case when modal toggles completion', () => {
+    const start = new Date('2026-01-01');
+    const t = new Task('t1', 's1', 'Name', false, start, 'Desc', undefined, undefined, undefined, undefined, []);
+    store.mergeTasks([t]);
+
+    store.editTask('p1', 't1', 'Name', 'Desc', start, undefined, true);
+
+    expect(updateExecute).toHaveBeenCalledTimes(1);
+    expect(completeExecute).not.toHaveBeenCalled();
+    expect(uncompleteExecute).not.toHaveBeenCalled();
+    const updatedArg = updateExecute.mock.calls[0]?.[1] as Task;
+    expect(updatedArg.completed).toBe(true);
+    expect(updatedArg.completedDate).toBeDefined();
+  });
+
+  it('editTask uncompletes via update use case when modal toggles completion', () => {
+    const start = new Date('2026-01-01');
+    const done = new Date('2026-01-02');
+    const t = new Task('t1', 's1', 'Name', true, start, 'Desc', undefined, undefined, done, undefined, []);
+    store.mergeTasks([t]);
+
+    store.editTask('p1', 't1', 'Name', 'Desc', start, undefined, true);
+
+    expect(updateExecute).toHaveBeenCalledTimes(1);
+    expect(completeExecute).not.toHaveBeenCalled();
+    expect(uncompleteExecute).not.toHaveBeenCalled();
+    expect((updateExecute.mock.calls[0]?.[1] as Task).completed).toBe(false);
   });
 
   it('editTask updates multiple fields when use case succeeds', () => {

--- a/src/app/features/projects/presentation/store/task.store.ts
+++ b/src/app/features/projects/presentation/store/task.store.ts
@@ -10,6 +10,12 @@ import { toProjectsUiError } from '@features/projects/presentation/mappers/proje
 import { ProjectsError } from '@features/projects/application/errors/projects.error';
 import { UiError } from '@features/projects/presentation/models/ui-error';
 
+/** Deep-cloned tasks + optional parent captured before optimistic delete (`removeTask`). */
+export interface OptimisticDeleteSnapshot {
+  readonly subtreeReplicas: readonly Task[];
+  readonly parentReplica: Task | null;
+}
+
 /**
  * Normalized store for **tasks** (and subtasks).
  *
@@ -79,6 +85,93 @@ export class TaskStore {
       }
       return { ...s, tasks: merged };
     });
+  }
+
+  /**
+   * Apply a persisted task snapshot from flows that do not run through TaskStore mutations
+   * (for example Today view). Keeps parent/subtask links when this task already exists so
+   * flat API responses cannot wipe nested structure after the user revisits Project view.
+   */
+  mergeExternalTask(task: Task): void {
+    const existing = this.state().tasks[task.id];
+    if (!existing) {
+      this.mergeTasks([task]);
+      return;
+    }
+
+    const subtaskIds = existing.subtaskIds.length > 0 ? existing.subtaskIds : task.subtaskIds;
+    const merged = new Task(
+      task.id,
+      task.sectionId,
+      task.name,
+      task.completed,
+      task.startDate,
+      task.description,
+      task.label ?? existing.label,
+      task.endDate,
+      task.completedDate,
+      existing.parentTaskId ?? task.parentTaskId,
+      subtaskIds,
+    );
+    this.mergeTasks([merged]);
+  }
+
+  /**
+   * Captures clones of the task subtree (+ parent row) immediately before optimistic delete so
+   * {@link rollbackOptimisticDelete} can rebuild `parent.subtaskIds` and descendants on failure.
+   */
+  snapshotForOptimisticDelete(taskId: string): OptimisticDeleteSnapshot | null {
+    const tasksDict = this.state().tasks;
+    const root = tasksDict[taskId];
+    if (!root) return null;
+
+    const ids = this.collectTaskAndDescendants(taskId, tasksDict);
+    const subtreeReplicas = ids.map(id => TaskStore.replicateTask(tasksDict[id]));
+
+    let parentReplica: Task | null = null;
+    if (root.parentTaskId) {
+      const p = tasksDict[root.parentTaskId];
+      if (p) parentReplica = TaskStore.replicateTask(p);
+    }
+
+    return { subtreeReplicas, parentReplica };
+  }
+
+  /** Restores dictionary rows after a failed optimistic delete. */
+  rollbackOptimisticDelete(snapshot: OptimisticDeleteSnapshot): void {
+    this.mergeTasks([...snapshot.subtreeReplicas]);
+    if (snapshot.parentReplica !== null) {
+      this.mergeTasks([snapshot.parentReplica]);
+    }
+  }
+
+  /**
+   * Reverts {@link mergeExternalTask} when the persistence call fails — pass the snapshot from
+   * {@link getTask} **before** the optimistic merge; `undefined` means the row was absent and
+   * should be dropped again after an optimistic upsert.
+   */
+  rollbackExternalTaskMerge(taskId: string, prior: Task | undefined): void {
+    if (prior !== undefined) {
+      this.mergeTasks([prior]);
+    } else {
+      this.removeTask(taskId);
+    }
+  }
+
+  private static replicateTask(task: Task): Task {
+    return new Task(
+      task.id,
+      task.sectionId,
+      task.name,
+      task.completed,
+      task.startDate,
+      task.description,
+      task.label,
+      task.endDate,
+      task.completedDate,
+      task.parentTaskId,
+      [...task.subtaskIds],
+    );
   }
 
   // ===================================================================
@@ -191,6 +284,7 @@ export class TaskStore {
       existing.description,
       existing.startDate,
       existing.endDate,
+      false,
     );
   }
 
@@ -202,22 +296,28 @@ export class TaskStore {
     description?: string,
     startDate?: Date,
     endDate?: Date,
+    completionChanged?: boolean,
   ): void {
     const existing = this.state().tasks[taskId];
     if (!existing) return;
 
     const updatedName = name.trim();
     const normalizedDescription = description?.trim() ? description.trim() : undefined;
-    const nextTask = existing
+    let nextTask = existing
       .updateName(updatedName)
       .updateDescription(normalizedDescription ?? '')
       .setStartDate(startDate)
       .setEndDate(endDate);
 
+    if (completionChanged) {
+      nextTask = existing.completed ? nextTask.uncomplete() : nextTask.complete();
+    }
+
     const hasChanges = nextTask.name !== existing.name
       || nextTask.description !== existing.description
       || nextTask.startDate?.getTime() !== existing.startDate?.getTime()
-      || nextTask.endDate?.getTime() !== existing.endDate?.getTime();
+      || nextTask.endDate?.getTime() !== existing.endDate?.getTime()
+      || nextTask.completed !== existing.completed;
     if (!hasChanges) return;
 
     this.state.update(s => ({

--- a/src/app/features/today/presentation/store/today.store.ts
+++ b/src/app/features/today/presentation/store/today.store.ts
@@ -13,6 +13,7 @@ import { UncompleteTaskUseCase } from '@features/projects/application/use-cases/
 import { UpdateTaskUseCase } from '@features/projects/application/use-cases/tasks/update-task/update-task.use-case';
 import { DeleteTaskUseCase } from '@features/projects/application/use-cases/tasks/delete-task/delete-task.use-case';
 import { TodayState, initialTodayState } from '@features/today/presentation/models/today.state';
+import { TaskStore } from '@features/projects/presentation/store/task.store';
 
 /**
  * Store for the Today view.
@@ -27,6 +28,7 @@ export class TodayStore {
   private readonly uncompleteTaskUseCase = inject(UncompleteTaskUseCase);
   private readonly updateTaskUseCase = inject(UpdateTaskUseCase);
   private readonly deleteTaskUseCase = inject(DeleteTaskUseCase);
+  private readonly taskStore = inject(TaskStore);
   private readonly state = signal<TodayState>(initialTodayState);
 
   // ===================================================================
@@ -112,8 +114,10 @@ export class TodayStore {
     const aggregate = this.resolveAggregate(event.id);
     if (!aggregate) return;
     const previousState = this.state();
+    const priorInTaskStore = this.taskStore.getTask(event.id);
     const toggledTask = aggregate.task.completed ? aggregate.task.uncomplete() : aggregate.task.complete();
     this.replaceAggregateTask(event.id, toggledTask);
+    this.taskStore.mergeExternalTask(toggledTask);
 
     const request$ = aggregate.task.completed
       ? this.uncompleteTaskUseCase.execute(aggregate.projectId, aggregate.task)
@@ -123,13 +127,16 @@ export class TodayStore {
       next: (result) => {
         if (!result.success) {
           this.state.set(previousState);
+          this.taskStore.rollbackExternalTaskMerge(event.id, priorInTaskStore);
           this.state.update((s) => ({ ...s, error: 'Failed to update task completion.' }));
           return;
         }
         this.replaceAggregateTask(event.id, result.value);
+        this.taskStore.mergeExternalTask(result.value);
       },
       error: () => {
         this.state.set(previousState);
+        this.taskStore.rollbackExternalTaskMerge(event.id, priorInTaskStore);
         this.state.update((s) => ({ ...s, error: 'Failed to update task completion.' }));
       },
     });
@@ -139,20 +146,25 @@ export class TodayStore {
     const aggregate = this.resolveAggregate(event.id);
     if (!aggregate) return;
     const previousState = this.state();
+    const priorInTaskStore = this.taskStore.getTask(event.id);
     const renamedTask = aggregate.task.updateName(event.name.trim());
     this.replaceAggregateTask(event.id, renamedTask);
+    this.taskStore.mergeExternalTask(renamedTask);
 
     this.updateTaskUseCase.execute(aggregate.projectId, renamedTask).subscribe({
       next: (result) => {
         if (!result.success) {
           this.state.set(previousState);
+          this.taskStore.rollbackExternalTaskMerge(event.id, priorInTaskStore);
           this.state.update((s) => ({ ...s, error: 'Failed to rename task.' }));
           return;
         }
         this.replaceAggregateTask(event.id, result.value);
+        this.taskStore.mergeExternalTask(result.value);
       },
       error: () => {
         this.state.set(previousState);
+        this.taskStore.rollbackExternalTaskMerge(event.id, priorInTaskStore);
         this.state.update((s) => ({ ...s, error: 'Failed to rename task.' }));
       },
     });
@@ -162,14 +174,26 @@ export class TodayStore {
     const aggregate = this.resolveAggregate(event.id);
     if (!aggregate) return;
     const previousState = this.state();
+    const optimisticDeleteSnapshot = this.taskStore.snapshotForOptimisticDelete(event.id);
+
     this.state.update((s) => ({
       ...s,
       aggregates: s.aggregates.filter((a) => a.task.id !== event.id),
     }));
 
+    if (optimisticDeleteSnapshot !== null) {
+      this.taskStore.removeTask(event.id);
+    }
+
     this.deleteTaskUseCase.execute(aggregate.projectId, event.sectionId, event.id).subscribe({
+      next: () => {
+        /* Optimistic remove already cleared TaskStore rows. */
+      },
       error: () => {
         this.state.set(previousState);
+        if (optimisticDeleteSnapshot !== null) {
+          this.taskStore.rollbackOptimisticDelete(optimisticDeleteSnapshot);
+        }
         this.state.update((s) => ({ ...s, error: 'Failed to delete task.' }));
       },
     });
@@ -180,52 +204,35 @@ export class TodayStore {
     if (!aggregate) return;
 
     const previousState = this.state();
+    const priorInTaskStore = this.taskStore.getTask(event.id);
     const normalizedDescription = event.description?.trim() ? event.description.trim() : undefined;
     const baseUpdatedTask = aggregate.task
       .updateName(event.name.trim())
       .updateDescription(normalizedDescription ?? '')
       .setStartDate(event.startDate)
       .setEndDate(event.endDate);
-    const optimisticTask = event.completedChanged
+    const nextTask = event.completedChanged
       ? (aggregate.task.completed ? baseUpdatedTask.uncomplete() : baseUpdatedTask.complete())
       : baseUpdatedTask;
 
-    this.replaceAggregateTask(event.id, optimisticTask);
+    this.replaceAggregateTask(event.id, nextTask);
+    this.taskStore.mergeExternalTask(nextTask);
 
-    this.updateTaskUseCase.execute(aggregate.projectId, baseUpdatedTask).subscribe({
+    this.updateTaskUseCase.execute(aggregate.projectId, nextTask).subscribe({
       next: (updateResult) => {
         if (!updateResult.success) {
           this.state.set(previousState);
+          this.taskStore.rollbackExternalTaskMerge(event.id, priorInTaskStore);
           this.state.update((s) => ({ ...s, error: 'Failed to edit task.' }));
           return;
         }
 
-        if (!event.completedChanged) {
-          this.replaceAggregateTask(event.id, updateResult.value);
-          return;
-        }
-
-        const completion$ = aggregate.task.completed
-          ? this.uncompleteTaskUseCase.execute(aggregate.projectId, updateResult.value)
-          : this.completeTaskUseCase.execute(aggregate.projectId, updateResult.value);
-
-        completion$.subscribe({
-          next: (completionResult) => {
-            if (!completionResult.success) {
-              this.state.set(previousState);
-              this.state.update((s) => ({ ...s, error: 'Failed to edit task.' }));
-              return;
-            }
-            this.replaceAggregateTask(event.id, completionResult.value);
-          },
-          error: () => {
-            this.state.set(previousState);
-            this.state.update((s) => ({ ...s, error: 'Failed to edit task.' }));
-          },
-        });
+        this.replaceAggregateTask(event.id, updateResult.value);
+        this.taskStore.mergeExternalTask(updateResult.value);
       },
       error: () => {
         this.state.set(previousState);
+        this.taskStore.rollbackExternalTaskMerge(event.id, priorInTaskStore);
         this.state.update((s) => ({ ...s, error: 'Failed to edit task.' }));
       },
     });


### PR DESCRIPTION
This PR solves issue #116 . Many other changes have to be made as well for sharing all the views state and showing the task update through optimistic UI.

We are basically sending the task completedDate in the same request as where we edited the name, description, start and end date.

This prevents having to do double updates (the above info and another request just for the task completion).

Verification of this behavior:

https://github.com/user-attachments/assets/92694563-5b1e-4313-9e28-c5912778f63d


---

AI Summary:
This pull request introduces several improvements and refactors to the task editing and synchronization logic, particularly focusing on how task completion and updates are handled between the project and today views. It replaces the previous `completed` boolean with a `completedDate` timestamp for better backend inference, ensures robust optimistic updates and rollbacks, and enhances the handling of external task snapshots to preserve task structure and state consistency across different parts of the app.

**Task completion and update model changes:**

- Replaces the `completed` boolean in `UpdateTaskDto` with a `completedDate` field, allowing the backend to infer completion status based on this timestamp.
- Updates `TaskMapper.toDto` to include `completedDate` only when appropriate, and adjusts related tests to verify this new behavior. 

**Optimistic update and rollback enhancements:**

- Implements `mergeExternalTask`, `rollbackExternalTaskMerge`, `snapshotForOptimisticDelete`, and `rollbackOptimisticDelete` in `TaskStore` to allow for robust optimistic updates and rollbacks, preserving parent/subtask relationships and supporting cross-view consistency.
- Adds comprehensive tests for these new optimistic update and rollback behaviors in `TaskStore`.

**Project and Today view synchronization:**

- Integrates the new task synchronization and rollback mechanisms into the `TodayStore`, ensuring that changes made in the Today view are reflected in the main task store and can be rolled back on failure, including for completion toggles, renames, and deletes.

**Edit task flow improvements:**

- Refactors the edit task flow to pass a `completionChanged` flag, allowing a single update operation to handle completion toggles and ensuring that the correct completion state and timestamp are sent to the backend. 

These changes collectively improve data consistency, enable more robust handling of optimistic UI updates, and streamline the way task completion is managed across the application.


