### PR TITLE
fix: allow tasks updates when start date was previous to today

### DIFF
--- a/src/app/shared/ui/task/task-edit-modal/task-edit-modal.component.html
+++ b/src/app/shared/ui/task/task-edit-modal/task-edit-modal.component.html
@@ -44,7 +44,7 @@
     <div class="date-grid">
       <div class="form-group">
         <label for="startDate">Start date</label>
-        <input id="startDate" type="date" formControlName="startDate" [min]="todayDateInput" />
+        <input id="startDate" type="date" formControlName="startDate" [attr.min]="minStartDate ?? null" />
         <button id="clearStartDate" type="button" class="clear-date-button" (click)="clearStartDate()">Clear start date</button>
         @if (taskForm.controls.startDate.touched && startDateError) {
           <span class="field-error">{{ startDateError }}</span>

--- a/src/app/shared/ui/task/task-edit-modal/task-edit-modal.component.html
+++ b/src/app/shared/ui/task/task-edit-modal/task-edit-modal.component.html
@@ -44,7 +44,7 @@
     <div class="date-grid">
       <div class="form-group">
         <label for="startDate">Start date</label>
-        <input id="startDate" type="date" formControlName="startDate" [attr.min]="minStartDate ?? null" />
+        <input id="startDate" type="date" formControlName="startDate" [attr.min]="minStartDate" />
         <button id="clearStartDate" type="button" class="clear-date-button" (click)="clearStartDate()">Clear start date</button>
         @if (taskForm.controls.startDate.touched && startDateError) {
           <span class="field-error">{{ startDateError }}</span>

--- a/src/app/shared/ui/task/task-edit-modal/task-edit-modal.component.spec.ts
+++ b/src/app/shared/ui/task/task-edit-modal/task-edit-modal.component.spec.ts
@@ -9,6 +9,7 @@ describe('TaskEditModalComponent', () => {
   let fixture: ComponentFixture<TaskEditModalComponent>;
   let modalRef: ModalRef<void>;
 
+  // Base setup: task has NO pre-existing start date, so the past-date validator is active.
   beforeEach(async () => {
     modalRef = { close: vi.fn() } as unknown as ModalRef<void>;
 
@@ -23,7 +24,6 @@ describe('TaskEditModalComponent', () => {
             name: 'Write release notes',
             completed: false,
             description: 'Details',
-            startDate: new Date(),
           },
         },
         { provide: ModalRef, useValue: modalRef },
@@ -124,5 +124,50 @@ describe('TaskEditModalComponent', () => {
 
     expect(modalRef.close).not.toHaveBeenCalled();
     expect(fixture.nativeElement.textContent).toContain('End date cannot be before start date');
+  });
+
+  describe('when the task already has a start date set in the past (loaded from backend)', () => {
+    beforeEach(async () => {
+      TestBed.resetTestingModule();
+      modalRef = { close: vi.fn() } as unknown as ModalRef<void>;
+
+      const pastDate = new Date();
+      pastDate.setDate(pastDate.getDate() - 30);
+
+      await TestBed.configureTestingModule({
+        imports: [TaskEditModalComponent],
+        providers: [
+          provideZonelessChangeDetection(),
+          {
+            provide: MODAL_DATA,
+            useValue: {
+              id: 't2',
+              name: 'Old task',
+              completed: false,
+              description: '',
+              startDate: pastDate,
+            },
+          },
+          { provide: ModalRef, useValue: modalRef },
+        ],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(TaskEditModalComponent);
+      fixture.detectChanges();
+    });
+
+    it('allows saving when the existing start date is in the past', () => {
+      const form: HTMLFormElement = fixture.nativeElement.querySelector('form');
+      form.dispatchEvent(new Event('submit'));
+      fixture.detectChanges();
+
+      expect(modalRef.close).toHaveBeenCalled();
+      expect(fixture.nativeElement.textContent).not.toContain('Start date cannot be before today');
+    });
+
+    it('does not apply a min-date restriction on the start date input', () => {
+      const startDateInput: HTMLInputElement = fixture.nativeElement.querySelector('#startDate');
+      expect(startDateInput.getAttribute('min')).toBeNull();
+    });
   });
 });

--- a/src/app/shared/ui/task/task-edit-modal/task-edit-modal.component.spec.ts
+++ b/src/app/shared/ui/task/task-edit-modal/task-edit-modal.component.spec.ts
@@ -170,4 +170,59 @@ describe('TaskEditModalComponent', () => {
       expect(startDateInput.getAttribute('min')).toBeNull();
     });
   });
+
+  describe('when the task already has a start date set in the future', () => {
+    beforeEach(async () => {
+      TestBed.resetTestingModule();
+      modalRef = { close: vi.fn() } as unknown as ModalRef<void>;
+
+      const futureDate = new Date();
+      futureDate.setDate(futureDate.getDate() + 30);
+
+      await TestBed.configureTestingModule({
+        imports: [TaskEditModalComponent],
+        providers: [
+          provideZonelessChangeDetection(),
+          {
+            provide: MODAL_DATA,
+            useValue: {
+              id: 't3',
+              name: 'Upcoming task',
+              completed: false,
+              description: '',
+              startDate: futureDate,
+            },
+          },
+          { provide: ModalRef, useValue: modalRef },
+        ],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(TaskEditModalComponent);
+      fixture.detectChanges();
+    });
+
+    it('still enforces the today-or-later restriction when a past date is entered', () => {
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      const yesterdayValue = `${yesterday.getFullYear()}-${`${yesterday.getMonth() + 1}`.padStart(2, '0')}-${`${yesterday.getDate()}`.padStart(2, '0')}`;
+
+      const startDateInput: HTMLInputElement = fixture.nativeElement.querySelector('#startDate');
+      startDateInput.value = yesterdayValue;
+      startDateInput.dispatchEvent(new Event('input'));
+      startDateInput.dispatchEvent(new Event('change'));
+      fixture.detectChanges();
+
+      const form: HTMLFormElement = fixture.nativeElement.querySelector('form');
+      form.dispatchEvent(new Event('submit'));
+      fixture.detectChanges();
+
+      expect(modalRef.close).not.toHaveBeenCalled();
+      expect(fixture.nativeElement.textContent).toContain('Start date cannot be before today');
+    });
+
+    it('applies a min-date restriction on the start date input', () => {
+      const startDateInput: HTMLInputElement = fixture.nativeElement.querySelector('#startDate');
+      expect(startDateInput.getAttribute('min')).not.toBeNull();
+    });
+  });
 });

--- a/src/app/shared/ui/task/task-edit-modal/task-edit-modal.component.spec.ts
+++ b/src/app/shared/ui/task/task-edit-modal/task-edit-modal.component.spec.ts
@@ -127,11 +127,13 @@ describe('TaskEditModalComponent', () => {
   });
 
   describe('when the task already has a start date set in the past (loaded from backend)', () => {
+    let pastDate: Date;
+
     beforeEach(async () => {
       TestBed.resetTestingModule();
       modalRef = { close: vi.fn() } as unknown as ModalRef<void>;
 
-      const pastDate = new Date();
+      pastDate = new Date();
       pastDate.setDate(pastDate.getDate() - 30);
 
       await TestBed.configureTestingModule({
@@ -156,18 +158,58 @@ describe('TaskEditModalComponent', () => {
       fixture.detectChanges();
     });
 
-    it('allows saving when the existing start date is in the past', () => {
+    it('allows saving when the existing past start date is unchanged', () => {
       const form: HTMLFormElement = fixture.nativeElement.querySelector('form');
       form.dispatchEvent(new Event('submit'));
       fixture.detectChanges();
 
       expect(modalRef.close).toHaveBeenCalled();
-      expect(fixture.nativeElement.textContent).not.toContain('Start date cannot be before today');
+      expect(fixture.nativeElement.textContent).not.toContain('Start date cannot be');
     });
 
-    it('does not apply a min-date restriction on the start date input', () => {
+    it('sets the min attribute on the start date input to the original start date', () => {
+      const year = pastDate.getFullYear();
+      const month = `${pastDate.getMonth() + 1}`.padStart(2, '0');
+      const day = `${pastDate.getDate()}`.padStart(2, '0');
+      const expectedMin = `${year}-${month}-${day}`;
+
       const startDateInput: HTMLInputElement = fixture.nativeElement.querySelector('#startDate');
-      expect(startDateInput.getAttribute('min')).toBeNull();
+      expect(startDateInput.getAttribute('min')).toBe(expectedMin);
+    });
+
+    it('does not allow setting a date before the original start date', () => {
+      const beforeOriginal = new Date(pastDate);
+      beforeOriginal.setDate(beforeOriginal.getDate() - 1);
+      const value = `${beforeOriginal.getFullYear()}-${`${beforeOriginal.getMonth() + 1}`.padStart(2, '0')}-${`${beforeOriginal.getDate()}`.padStart(2, '0')}`;
+
+      const startDateInput: HTMLInputElement = fixture.nativeElement.querySelector('#startDate');
+      startDateInput.value = value;
+      startDateInput.dispatchEvent(new Event('input'));
+      startDateInput.dispatchEvent(new Event('change'));
+      fixture.detectChanges();
+
+      const form: HTMLFormElement = fixture.nativeElement.querySelector('form');
+      form.dispatchEvent(new Event('submit'));
+      fixture.detectChanges();
+
+      expect(modalRef.close).not.toHaveBeenCalled();
+      expect(fixture.nativeElement.textContent).toContain('Start date cannot be moved further into the past than the original date');
+    });
+
+    it('allows saving when the start date is changed to a future date', () => {
+      const futureValue = '2099-12-31';
+
+      const startDateInput: HTMLInputElement = fixture.nativeElement.querySelector('#startDate');
+      startDateInput.value = futureValue;
+      startDateInput.dispatchEvent(new Event('input'));
+      startDateInput.dispatchEvent(new Event('change'));
+      fixture.detectChanges();
+
+      const form: HTMLFormElement = fixture.nativeElement.querySelector('form');
+      form.dispatchEvent(new Event('submit'));
+      fixture.detectChanges();
+
+      expect(modalRef.close).toHaveBeenCalled();
     });
   });
 

--- a/src/app/shared/ui/task/task-edit-modal/task-edit-modal.component.ts
+++ b/src/app/shared/ui/task/task-edit-modal/task-edit-modal.component.ts
@@ -19,6 +19,15 @@ export class TaskEditModalComponent {
   protected readonly completed = signal(this.modalData?.completed ?? false);
   protected readonly todayDateInput = this.toDateInputValue(new Date());
 
+  /**
+   * Only restrict the start-date picker to today-or-later when the task has no
+   * pre-existing start date.  Tasks whose start date was already set in the past
+   * (e.g. loaded from the backend) must remain submittable as-is.
+   */
+  protected readonly minStartDate: string | undefined = this.modalData?.startDate
+    ? undefined
+    : this.toDateInputValue(new Date());
+
   protected readonly taskForm = new FormGroup({
     name: new FormControl(this.modalData?.name ?? '', {
       nonNullable: true,
@@ -30,7 +39,7 @@ export class TaskEditModalComponent {
     }),
     startDate: new FormControl(this.toDateInputValue(this.modalData?.startDate), {
       nonNullable: true,
-      validators: [this.minTodayDateValidator()],
+      validators: this.modalData?.startDate ? [] : [this.minTodayDateValidator()],
     }),
     endDate: new FormControl(this.toDateInputValue(this.modalData?.endDate), {
       nonNullable: true,

--- a/src/app/shared/ui/task/task-edit-modal/task-edit-modal.component.ts
+++ b/src/app/shared/ui/task/task-edit-modal/task-edit-modal.component.ts
@@ -20,21 +20,38 @@ export class TaskEditModalComponent {
   protected readonly todayDateInput = this.toDateInputValue(new Date());
 
   /**
-   * True only when the task already has a start date that is strictly in the
-   * past.  Tasks with a future (or today's) start date still enforce the
-   * today-or-later constraint so the user cannot backdate them freely.
+   * The earliest date the user may select for the start date:
+   * - No original start date     → today (cannot pick a date in the past)
+   * - Original date today/future → today (same constraint)
+   * - Original date in the past  → the original date itself (cannot push the
+   *   start date further back than it was already assigned, but today-or-later
+   *   restriction is lifted because the date is already past)
    */
-  private readonly existingStartDateIsInPast: boolean = (() => {
-    const existing = this.modalData?.startDate;
-    if (!existing) return false;
+  private readonly minAllowedStartDate: Date = (() => {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
-    return existing < today;
+
+    const existing = this.modalData?.startDate;
+    if (existing) {
+      const existingNormalized = new Date(existing);
+      existingNormalized.setHours(0, 0, 0, 0);
+      if (existingNormalized < today) return existingNormalized;
+    }
+
+    return today;
   })();
 
-  protected readonly minStartDate: string | undefined = this.existingStartDateIsInPast
-    ? undefined
-    : this.toDateInputValue(new Date());
+  protected readonly minStartDate: string = this.toDateInputValue(this.minAllowedStartDate);
+
+  private readonly existingStartDateIsInPast: boolean = (() => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const existing = this.modalData?.startDate;
+    if (!existing) return false;
+    const existingNormalized = new Date(existing);
+    existingNormalized.setHours(0, 0, 0, 0);
+    return existingNormalized < today;
+  })();
 
   protected readonly taskForm = new FormGroup({
     name: new FormControl(this.modalData?.name ?? '', {
@@ -47,7 +64,10 @@ export class TaskEditModalComponent {
     }),
     startDate: new FormControl(this.toDateInputValue(this.modalData?.startDate), {
       nonNullable: true,
-      validators: this.existingStartDateIsInPast ? [] : [this.minTodayDateValidator()],
+      validators: [this.minDateValidator(
+        this.minAllowedStartDate,
+        this.existingStartDateIsInPast ? 'minOriginalDate' : 'minToday',
+      )],
     }),
     endDate: new FormControl(this.toDateInputValue(this.modalData?.endDate), {
       nonNullable: true,
@@ -71,6 +91,7 @@ export class TaskEditModalComponent {
     const errors = this.taskForm.controls.startDate.errors;
     if (!errors) return null;
     if (errors['minToday']) return 'Start date cannot be before today';
+    if (errors['minOriginalDate']) return 'Start date cannot be moved further into the past than the original date';
     return null;
   }
 
@@ -123,18 +144,15 @@ export class TaskEditModalComponent {
     return `${year}-${month}-${day}`;
   }
 
-  private minTodayDateValidator(): ValidatorFn {
+  private minDateValidator(minDate: Date, errorKey: string): ValidatorFn {
     return (control: AbstractControl<string>): ValidationErrors | null => {
       const value = control.value;
       if (!value) return null;
 
-      const today = new Date();
-      today.setHours(0, 0, 0, 0);
-
       const selectedDate = new Date(`${value}T00:00:00`);
       if (Number.isNaN(selectedDate.getTime())) return null;
 
-      return selectedDate < today ? { minToday: true } : null;
+      return selectedDate < minDate ? { [errorKey]: true } : null;
     };
   }
 

--- a/src/app/shared/ui/task/task-edit-modal/task-edit-modal.component.ts
+++ b/src/app/shared/ui/task/task-edit-modal/task-edit-modal.component.ts
@@ -20,11 +20,19 @@ export class TaskEditModalComponent {
   protected readonly todayDateInput = this.toDateInputValue(new Date());
 
   /**
-   * Only restrict the start-date picker to today-or-later when the task has no
-   * pre-existing start date.  Tasks whose start date was already set in the past
-   * (e.g. loaded from the backend) must remain submittable as-is.
+   * True only when the task already has a start date that is strictly in the
+   * past.  Tasks with a future (or today's) start date still enforce the
+   * today-or-later constraint so the user cannot backdate them freely.
    */
-  protected readonly minStartDate: string | undefined = this.modalData?.startDate
+  private readonly existingStartDateIsInPast: boolean = (() => {
+    const existing = this.modalData?.startDate;
+    if (!existing) return false;
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    return existing < today;
+  })();
+
+  protected readonly minStartDate: string | undefined = this.existingStartDateIsInPast
     ? undefined
     : this.toDateInputValue(new Date());
 
@@ -39,7 +47,7 @@ export class TaskEditModalComponent {
     }),
     startDate: new FormControl(this.toDateInputValue(this.modalData?.startDate), {
       nonNullable: true,
-      validators: this.modalData?.startDate ? [] : [this.minTodayDateValidator()],
+      validators: this.existingStartDateIsInPast ? [] : [this.minTodayDateValidator()],
     }),
     endDate: new FormControl(this.toDateInputValue(this.modalData?.endDate), {
       nonNullable: true,


### PR DESCRIPTION
This basically solves issue #113.

Verification of this expected behavior:


https://github.com/user-attachments/assets/cf81953a-17df-4fc6-abee-9ff658cfb8f1

