### PR TITLE
Feat/logout

### DIFF
--- a/src/app/features/auth/presentation/store/auth.store.ts
+++ b/src/app/features/auth/presentation/store/auth.store.ts
@@ -1,5 +1,5 @@
 import { computed, inject, Injectable, signal } from "@angular/core";
-import { catchError, of, tap } from "rxjs";
+import { Observable, catchError, of, tap } from "rxjs";
 import { LoginUseCase } from "@features/auth/application/use-cases/login.use-case";
 import { LogoutUseCase } from "@features/auth/application/use-cases/logout.use-case";
 import { GetCurrentUserUseCase } from "@features/auth/application/use-cases/getCurrentUser.use-case";
@@ -109,13 +109,15 @@ export class AuthStore {
     ).subscribe();
   }
 
-  logout(): void {
-    this.logoutUseCase.execute().subscribe({
-      next: () => {
-        // Server cleared the cookie
+  logout(): Observable<void> {
+    this.state.update(s => ({ ...s, isLoading: true }));
+    return this.logoutUseCase.execute().pipe(
+      tap(() => this.clearSessionState()),
+      catchError(() => {
         this.clearSessionState();
-      },
-    });
+        return of(void 0);
+      })
+    );
   }
 
   clearSessionState(): void {

--- a/src/app/shared/ui/modal/confirm/confirm.component.html
+++ b/src/app/shared/ui/modal/confirm/confirm.component.html
@@ -1,7 +1,11 @@
 <div class="confirm-modal">
   <p class="confirm-modal-message">
-    Are you sure you want to delete <strong>"{{ entityName }}"</strong>?
-    This item will be deleted <strong>permanently</strong>.
+    @if (message) {
+      {{ message }}
+    } @else {
+      Are you sure you want to delete <strong>"{{ entityName }}"</strong>?
+      This item will be deleted <strong>permanently</strong>.
+    }
     @if (cascadeMessage) {
       {{ cascadeMessage }}
     }

--- a/src/app/shared/ui/modal/confirm/confirm.component.ts
+++ b/src/app/shared/ui/modal/confirm/confirm.component.ts
@@ -3,6 +3,7 @@ import { MODAL_DATA, ModalRef } from '@shared/ui/modal/modal-ref';
 
 interface ConfirmModalData {
   entityName: string;
+  message?: string;
   cascadeMessage?: string;
   confirmLabel?: string;
   cancelLabel?: string;
@@ -20,6 +21,7 @@ export class ConfirmComponent {
   private readonly modalData = inject<ConfirmModalData>(MODAL_DATA);
 
   protected readonly entityName = this.modalData.entityName;
+  protected readonly message = this.modalData.message;
   protected readonly cascadeMessage = this.modalData.cascadeMessage;
   protected readonly confirmLabel = this.modalData.confirmLabel ?? 'Delete';
   protected readonly cancelLabel = this.modalData.cancelLabel ?? 'Cancel';

--- a/src/app/shared/ui/sidebar/sidebar.component.html
+++ b/src/app/shared/ui/sidebar/sidebar.component.html
@@ -39,7 +39,7 @@
               <a>Configuration</a>
             </button>
             <hr>
-            <div>
+            <button type="button" class="dropdown-action" (click)="onLogoutClick()">
               <svg id="log-out-ico" width="24px" height="24px" viewBox="0 0 24 24" fill="none"
                 xmlns="http://www.w3.org/2000/svg" stroke="#000" stroke-width="1" stroke-linecap="round"
                 stroke-linejoin="round">
@@ -48,8 +48,8 @@
                 <path
                   d="M16 5V4.5C16 3.67157 15.3284 3 14.5 3H5C3.89543 3 3 3.89543 3 5V19C3 20.1046 3.89543 21 5 21H14.5C15.3284 21 16 20.3284 16 19.5V19" />
               </svg>
-              <a href="#">Log Out</a>
-            </div>
+              <a>Log Out</a>
+            </button>
           </div>
         </div>
       </div>

--- a/src/app/shared/ui/sidebar/sidebar.component.ts
+++ b/src/app/shared/ui/sidebar/sidebar.component.ts
@@ -1,8 +1,9 @@
-import { NgClass } from '@angular/common';
+import { DOCUMENT, NgClass } from '@angular/common';
 import { Component, computed, input, output, signal, inject, ChangeDetectionStrategy } from '@angular/core';
 import { ModalService } from '@shared/ui/modal/modal.service';
 import { ConfigurationComponent } from '@shared/ui/modal/configuration/configuration.component';
 import { ProfileComponent } from '@shared/ui/modal/profile/profile.component';
+import { ConfirmComponent } from '@shared/ui/modal/confirm/confirm.component';
 import { TWDSidebarMenu, TWDSidebarMenuItem } from '@shared/ui/sidebar/sidebar-menu';
 import { MenuSectionComponent } from '@shared/ui/sidebar/sidebar-menu-section/menu-section.component';
 import { ClickOutsideDirective } from '@shared/directives/click-outside.directive';
@@ -18,6 +19,7 @@ import { AuthStore } from '@features/auth/presentation/store/auth.store';
 export class SidebarComponent {
   private readonly modalService = inject(ModalService);
   private readonly authStore = inject(AuthStore);
+  private readonly document = inject(DOCUMENT);
 
   readonly user = computed(() => this.authStore.user());
 
@@ -44,6 +46,38 @@ export class SidebarComponent {
   openConfigurationModal(): void {
     this.closeDropdown();
     this.modalService.open(ConfigurationComponent, { title: 'Configuration' });
+  }
+
+  onLogoutClick(): void {
+    this.closeDropdown();
+    this.modalService.open(ConfirmComponent, {
+      title: 'Log out',
+      data: {
+        entityName: 'session',
+        message: 'Are you sure you want to log out? You will need to sign in again to access your projects.',
+        confirmLabel: 'Log out',
+        cancelLabel: 'Cancel',
+      },
+      onClose: (result) => {
+        if (result === true) {
+          this.performLogout();
+        }
+      },
+    });
+  }
+
+  private performLogout(): void {
+    this.authStore.logout().subscribe({
+      complete: () => this.hardRedirectToLogin(),
+    });
+  }
+
+  private hardRedirectToLogin(): void {
+    const win = this.document.defaultView;
+    if (win) {
+      win.location.hash = '#/auth/login';
+      win.location.reload();
+    }
   }
 
   onCreateProjectClick(): void {


### PR DESCRIPTION
Basically added all the functionality for logging out from the account. This includes a confirmation before logging out.

To ensure that there aren't any inconsistencies in the state, I force a window reload after login (simplest solution)

Demo:

https://github.com/user-attachments/assets/760bd66c-44c0-4de7-82ac-c82bd17e983a




---

AI summary:

This pull request introduces a user confirmation modal for logging out, refactors the logout flow to be observable-based, and improves the sidebar's logout UX. The most important changes are grouped below.

**Logout Flow and UX Improvements:**

* The sidebar logout action now opens a confirmation modal (`ConfirmComponent`) before logging out, providing a custom message and requiring user confirmation. [[1]](diffhunk://#diff-b3f71da3123831d64df7eb8ba342a2993a08e02ddf846ea5b4478f288047a728L42-R42) [[2]](diffhunk://#diff-b3f71da3123831d64df7eb8ba342a2993a08e02ddf846ea5b4478f288047a728L51-R52) [[3]](diffhunk://#diff-63e54ee217eadea1b55a9a88a3223aac645fa4d6e9ec5f9ffef4506e6e4131d9R51-R82)
* The `logout()` method in `AuthStore` is refactored to return an `Observable<void>`, making it easier to handle logout completion and errors reactively.
* After confirming logout, the app performs a hard redirect to the login page to fully clear the session and reload the state.

**Modal and Component Enhancements:**

* The confirmation modal (`ConfirmComponent`) now supports an optional `message` field, allowing for customizable confirmation prompts. The template and TypeScript definitions are updated accordingly. [[1]](diffhunk://#diff-2ed42fe01b9486c9c6f0f161405e0513926fd37e01a11a8da665060aa743bff4R6) [[2]](diffhunk://#diff-2ed42fe01b9486c9c6f0f161405e0513926fd37e01a11a8da665060aa743bff4R24) [[3]](diffhunk://#diff-7c7b268e0926a8fbcc13a6ef67226016bb2f2156687a8225c92c92673a064f82R3-R8)
* Sidebar component imports and dependencies are updated to support the new modal and logout flow. [[1]](diffhunk://#diff-63e54ee217eadea1b55a9a88a3223aac645fa4d6e9ec5f9ffef4506e6e4131d9L1-R6) [[2]](diffhunk://#diff-63e54ee217eadea1b55a9a88a3223aac645fa4d6e9ec5f9ffef4506e6e4131d9R22)

These changes enhance user experience and reliability around session management and logout actions.