### PR TITLE
Fix/store state bleed

### DIFF
--- a/src/app/features/projects/presentation/components/home/home.component.spec.ts
+++ b/src/app/features/projects/presentation/components/home/home.component.spec.ts
@@ -138,6 +138,12 @@ describe('HomeComponent', () => {
         { provide: AuthStore, useValue: mockAuthStore },
       ],
     })
+      .overrideComponent(HomeComponent, {
+        set: { providers: [] },
+      })
+      .overrideComponent(TodayComponent, {
+        set: { providers: [{ provide: TodayStore, useValue: todayStoreMock }] },
+      })
       .overrideComponent(UpcomingComponent, {
         set: {
           providers: [{ provide: UpcomingStore, useValue: upcomingStoreMock }],
@@ -159,9 +165,8 @@ describe('HomeComponent', () => {
     expect(projectStoreMock.loadAllProjects).toHaveBeenCalled();
   });
 
-  it('calls disconnectFromEvents when destroyed', () => {
-    fixture.destroy();
-    expect(projectStoreMock.disconnectFromEvents).toHaveBeenCalled();
+  it('destroys without error (SSE cleanup delegated to ProjectStore.ngOnDestroy)', () => {
+    expect(() => fixture.destroy()).not.toThrow();
   });
 
   describe('right panel from route', () => {

--- a/src/app/features/projects/presentation/components/home/home.component.ts
+++ b/src/app/features/projects/presentation/components/home/home.component.ts
@@ -1,4 +1,4 @@
-import { Component, DestroyRef, inject, OnDestroy, OnInit, signal, computed, ChangeDetectionStrategy } from '@angular/core';
+import { Component, DestroyRef, inject, Injector, OnInit, signal, computed, ChangeDetectionStrategy } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NavigationEnd, Router, ActivatedRoute } from '@angular/router';
 import { filter, startWith } from 'rxjs';
@@ -8,6 +8,8 @@ import { ProjectStore } from '@features/projects/presentation/store/project.stor
 import { TodayComponent } from '@features/today/presentation/components/today/today.component';
 import { UpcomingComponent } from '@features/upcoming/presentation/components/upcoming/upcoming.component';
 import { ProjectSummaryStore } from '@features/projects/presentation/store/project-summary.store';
+import { SectionStore } from '@features/projects/presentation/store/section.store';
+import { TaskStore } from '@features/projects/presentation/store/task.store';
 import { TWDSidebarMenu, TWDSidebarMenuItem } from '@shared/ui/sidebar/sidebar-menu';
 import { ModalService } from '@shared/ui/modal/modal.service';
 import { CreateProjectComponent } from '@features/projects/presentation/components/create-project/create-project.component';
@@ -17,13 +19,15 @@ import { ConfirmComponent } from '@shared/ui/modal/confirm/confirm.component';
   selector: 'app-home',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [SidebarComponent, ProjectViewComponent, TodayComponent, UpcomingComponent],
+  providers: [ProjectStore, ProjectSummaryStore, SectionStore, TaskStore],
   templateUrl: './home.component.html',
   styleUrl: './home.component.css'
 })
-export class HomeComponent implements OnInit, OnDestroy {
+export class HomeComponent implements OnInit {
   private readonly projectStore = inject(ProjectStore);
   private readonly summaryStore = inject(ProjectSummaryStore);
   private readonly modalService = inject(ModalService);
+  private readonly injector = inject(Injector);
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);
   private readonly destroyRef = inject(DestroyRef);
@@ -139,6 +143,7 @@ export class HomeComponent implements OnInit, OnDestroy {
     if (!project) return;
     this.modalService.open(CreateProjectComponent, {
       title: 'Edit Project',
+      parentInjector: this.injector,
       data: {
         id: project.id,
         name: project.name,
@@ -168,10 +173,9 @@ export class HomeComponent implements OnInit, OnDestroy {
   }
 
   protected openCreateProjectModal(): void {
-    this.modalService.open(CreateProjectComponent, { title: 'Create Project' });
-  }
-
-  ngOnDestroy(): void {
-    this.projectStore.disconnectFromEvents();
+    this.modalService.open(CreateProjectComponent, {
+      title: 'Create Project',
+      parentInjector: this.injector,
+    });
   }
 }

--- a/src/app/features/projects/presentation/store/project-summary.store.ts
+++ b/src/app/features/projects/presentation/store/project-summary.store.ts
@@ -17,7 +17,7 @@ import { TaskStore } from '@features/projects/presentation/store/task.store';
  * Deliberately kept separate from {@link ProjectStore} so the main project
  * state is not polluted with sidebar-only concerns.
  */
-@Injectable({ providedIn: 'root' })
+@Injectable()
 export class ProjectSummaryStore {
   private readonly sectionStore = inject(SectionStore);
   private readonly taskStore = inject(TaskStore);

--- a/src/app/features/projects/presentation/store/project.store.ts
+++ b/src/app/features/projects/presentation/store/project.store.ts
@@ -1,4 +1,4 @@
-import { computed, inject, Injectable, signal } from '@angular/core';
+import { computed, inject, Injectable, OnDestroy, signal } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { LoadProjectUseCase } from '@features/projects/application/use-cases/projects/load-project/load-project.use-case';
 import { LoadAllProjectsUseCase } from '@features/projects/application/use-cases/projects/load-all-projects/load-all-projects.use-case';
@@ -40,8 +40,8 @@ import { UiError } from '@features/projects/presentation/models/ui-error';
  * The `projectView` computed signal reads across all three stores
  * to build the denormalized tree the template needs.
  */
-@Injectable({ providedIn: 'root' })
-export class ProjectStore {
+@Injectable()
+export class ProjectStore implements OnDestroy {
   // --------------- Use-case injection ---------------
   private readonly loadProjectUseCase   = inject(LoadProjectUseCase);
   private readonly loadAllProjectsUseCase = inject(LoadAllProjectsUseCase);
@@ -565,6 +565,10 @@ export class ProjectStore {
   private disconnectFromUserEvents(): void {
     this.userEventsSubscription?.unsubscribe();
     this.userEventsSubscription = undefined;
+  }
+
+  ngOnDestroy(): void {
+    this.disconnectFromEvents();
   }
 
   /** Close all SSE connections. Call on logout / navigation away. */

--- a/src/app/features/projects/presentation/store/section.store.ts
+++ b/src/app/features/projects/presentation/store/section.store.ts
@@ -14,7 +14,7 @@ import { UiError } from '@features/projects/presentation/models/ui-error';
  * Each section lives as a flat entry keyed by ID.
  * `Section.taskIds` points into the TaskStore's dictionary.
  */
-@Injectable({ providedIn: 'root' })
+@Injectable()
 export class SectionStore {
   private readonly createSectionUseCase = inject(CreateSectionUseCase);
   private readonly updateSectionUseCase = inject(UpdateSectionUseCase);

--- a/src/app/features/projects/presentation/store/task.store.ts
+++ b/src/app/features/projects/presentation/store/task.store.ts
@@ -23,7 +23,7 @@ export interface OptimisticDeleteSnapshot {
  * `state.tasks`, keyed by its ID. Subtask relationships are expressed
  * through `Task.subtaskIds` (children) and `Task.parentTaskId` (parent).
  */
-@Injectable({ providedIn: 'root' })
+@Injectable()
 export class TaskStore {
   private readonly createTaskUseCase = inject(CreateTaskUseCase);
   private readonly completeTaskUseCase = inject(CompleteTaskUseCase);

--- a/src/app/features/projects/projects.providers.ts
+++ b/src/app/features/projects/projects.providers.ts
@@ -19,11 +19,6 @@ import { CompleteTaskUseCase } from '@features/projects/application/use-cases/ta
 import { UncompleteTaskUseCase } from '@features/projects/application/use-cases/tasks/uncomplete-task/uncomplete-task.use-case';
 import { UpdateTaskUseCase } from '@features/projects/application/use-cases/tasks/update-task/update-task.use-case';
 import { DeleteTaskUseCase } from '@features/projects/application/use-cases/tasks/delete-task/delete-task.use-case';
-import { ProjectStore } from '@features/projects/presentation/store/project.store';
-import { ProjectSummaryStore } from '@features/projects/presentation/store/project-summary.store';
-import { SectionStore } from '@features/projects/presentation/store/section.store';
-import { TaskStore } from '@features/projects/presentation/store/task.store';
-
 export const PROJECT_FEATURE_PROVIDERS: Provider[] = [
   // Repositories
   { provide: ProjectRepository, useClass: HttpProjectRepository },
@@ -45,10 +40,4 @@ export const PROJECT_FEATURE_PROVIDERS: Provider[] = [
   UpdateTaskUseCase,
   DeleteTaskUseCase,
   ToggleFavoriteUseCase,
-
-  // Presentation — Stores
-  ProjectStore,
-  ProjectSummaryStore,
-  SectionStore,
-  TaskStore,
 ];

--- a/src/app/features/today/presentation/components/today/today.component.spec.ts
+++ b/src/app/features/today/presentation/components/today/today.component.spec.ts
@@ -36,7 +36,11 @@ describe('TodayComponent', () => {
         provideZonelessChangeDetection(),
         { provide: TodayStore, useValue: todayStoreMock },
       ],
-    }).compileComponents();
+    })
+      .overrideComponent(TodayComponent, {
+        set: { providers: [{ provide: TodayStore, useValue: todayStoreMock }] },
+      })
+      .compileComponents();
 
     fixture = TestBed.createComponent(TodayComponent);
     fixture.componentRef.setInput('showIcon', false);
@@ -80,7 +84,11 @@ describe('Breadcrumb integration inside the TodayComponent', () => {
         provideZonelessChangeDetection(),
         { provide: TodayStore, useValue: todayStoreMock },
       ],
-    }).compileComponents();
+    })
+      .overrideComponent(TodayComponent, {
+        set: { providers: [{ provide: TodayStore, useValue: todayStoreMock }] },
+      })
+      .compileComponents();
     fixture = TestBed.createComponent(TodayComponent);
     fixture.componentRef.setInput('showIcon', false);
     component = fixture.componentInstance;

--- a/src/app/features/today/presentation/components/today/today.component.ts
+++ b/src/app/features/today/presentation/components/today/today.component.ts
@@ -14,6 +14,7 @@ import { TaskFilter } from '@shared/types/task-filter.type';
   selector: 'app-today',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [BreadcrumbComponent, TodayGroupComponent],
+  providers: [TodayStore],
   templateUrl: './today.component.html',
   styleUrl: './today.component.css',
 })

--- a/src/app/features/today/presentation/store/today.store.ts
+++ b/src/app/features/today/presentation/store/today.store.ts
@@ -21,7 +21,7 @@ import { TaskStore } from '@features/projects/presentation/store/task.store';
  * Reads tasks from the dedicated `/api/tasks/today` endpoint and keeps a
  * local optimistic state for task mutations.
  */
-@Injectable({ providedIn: 'root' })
+@Injectable()
 export class TodayStore {
   private readonly loadTodayTasksUseCase = inject(LoadTodayTasksUseCase);
   private readonly completeTaskUseCase = inject(CompleteTaskUseCase);

--- a/src/app/shared/ui/modal/modal.component.ts
+++ b/src/app/shared/ui/modal/modal.component.ts
@@ -38,7 +38,7 @@ export class ModalComponent {
     vcr.clear();
 
     const childInjector = Injector.create({
-      parent: this.injector,
+      parent: modal.config.parentInjector ?? this.injector,
       providers: [
         {
           provide: ModalRef,

--- a/src/app/shared/ui/modal/modal.service.ts
+++ b/src/app/shared/ui/modal/modal.service.ts
@@ -1,7 +1,8 @@
-import { Injectable, signal, Type } from '@angular/core';
+import { Injectable, Injector, signal, Type } from '@angular/core';
 
 export interface ModalConfig {
   title: string;
+  parentInjector?: Injector;
   data?: Record<string, unknown>;
   onClose?: (result?: unknown) => void;
 }


### PR DESCRIPTION
This basically solves issue #120 . Now keeping the DI only for what's intended. The stores are now only provided where they were supposed to be and not globally anymore if not needed.

This removes some technical debt and centralizes the logic in the store (e.g. -> No more OnDestroy in the components, this should all be managed in the stores themselves)

---
AI Summary:

This pull request refactors the way Angular stores and providers are registered and managed in the projects and today features. The main goal is to move from global, root-level store providers to feature/component-level providers, improving encapsulation and testability. The modal system is also updated to allow parent injector customization for better dependency injection in modals. Additionally, tests are updated to reflect these changes and ensure correct provider usage.

**Store Provider Refactoring:**

- Changed `ProjectStore`, `ProjectSummaryStore`, `SectionStore`, `TaskStore`, and `TodayStore` from being provided in the root injector (`@Injectable({ providedIn: 'root' })`) to having no provider scope, so they must be provided explicitly at the component or feature level. [[1]](diffhunk://#diff-22439a17c8205188f72d3c2d89f2e6333c3cbae2653cd24c08915f3358d4bbf1L20-R20) [[2]](diffhunk://#diff-4393967c21cce328b3ca37687b8eb4d46ede4b2e0525d804845c77a7d2457906L43-R44) [[3]](diffhunk://#diff-191d63f422562ffc4477933418834b40d654522aebb4d5ceedf945ff5f5bfe42L17-R17) [[4]](diffhunk://#diff-a54e487f0f0afe8c48f3c6f78030d477b92467f22c500c9dc33fdfc9e8040c5dL26-R26) [[5]](diffhunk://#diff-3113fe57414d91d6d9fc952ff0960221c5ff37fb91ec1d21082ba4efaa7daee8L24-R24)
- Added these stores to the `providers` array of their respective components (`HomeComponent`, `TodayComponent`) instead of the global `PROJECT_FEATURE_PROVIDERS` array. [[1]](diffhunk://#diff-49e03cccdbc82a3c280d6cfae09d9bead4e61f9e2295e2c069c3d9f3c5a42b42R22-R30) [[2]](diffhunk://#diff-8c796ea856eb59c4053a0dfaefd675c1ed3db558e257754e97195c3f7c9407f0R17) [[3]](diffhunk://#diff-f06124ff9c3cd1c914c8c23d7d2867775a7091492966c5f382989fb53da601a5L22-L26) [[4]](diffhunk://#diff-f06124ff9c3cd1c914c8c23d7d2867775a7091492966c5f382989fb53da601a5L48-L53)

**Lifecycle and Cleanup Improvements:**

- Implemented `OnDestroy` in `ProjectStore` and moved the SSE cleanup (`disconnectFromEvents`) to its `ngOnDestroy` method, removing manual cleanup from `HomeComponent`. [[1]](diffhunk://#diff-4393967c21cce328b3ca37687b8eb4d46ede4b2e0525d804845c77a7d2457906L1-R1) [[2]](diffhunk://#diff-4393967c21cce328b3ca37687b8eb4d46ede4b2e0525d804845c77a7d2457906R570-R573) [[3]](diffhunk://#diff-49e03cccdbc82a3c280d6cfae09d9bead4e61f9e2295e2c069c3d9f3c5a42b42L171-R179) [[4]](diffhunk://#diff-f8b47df5dc599ec745ffbf71bcb148be235711514c74ecf15e50520d219fab5aL162-R169)

**Modal Service Enhancements:**

- Updated `ModalService` and `ModalComponent` to accept an optional `parentInjector` in the modal config, allowing modals to resolve dependencies from the correct injector context. [[1]](diffhunk://#diff-9dc4f758a6321861ed1110758b2ef48a713277f223497a0455e3db32420b9528L41-R41) [[2]](diffhunk://#diff-d9cc77c58807b65ab6aeb46d712ac36f3db0e7a15e28e716d52ec3cbdbde62a5L1-R5) [[3]](diffhunk://#diff-49e03cccdbc82a3c280d6cfae09d9bead4e61f9e2295e2c069c3d9f3c5a42b42R146) [[4]](diffhunk://#diff-49e03cccdbc82a3c280d6cfae09d9bead4e61f9e2295e2c069c3d9f3c5a42b42L171-R179)

**Test Suite Updates:**

- Updated tests for `HomeComponent` and `TodayComponent` to use `.overrideComponent` with explicit provider overrides, aligning with the new provider registration strategy. [[1]](diffhunk://#diff-f8b47df5dc599ec745ffbf71bcb148be235711514c74ecf15e50520d219fab5aR140-R145) [[2]](diffhunk://#diff-c5e68ac9eb3b519b086088d14d5a07ba25988d9062f359784fd95b6e5c6142c6L39-R43) [[3]](diffhunk://#diff-c5e68ac9eb3b519b086088d14d5a07ba25988d9062f359784fd95b6e5c6142c6L83-R91)

**Dependency Injection Adjustments:**

- Added `Injector` injection in `HomeComponent` to support passing the correct injector to modals. [[1]](diffhunk://#diff-49e03cccdbc82a3c280d6cfae09d9bead4e61f9e2295e2c069c3d9f3c5a42b42L1-R1) [[2]](diffhunk://#diff-49e03cccdbc82a3c280d6cfae09d9bead4e61f9e2295e2c069c3d9f3c5a42b42R146) [[3]](diffhunk://#diff-49e03cccdbc82a3c280d6cfae09d9bead4e61f9e2295e2c069c3d9f3c5a42b42L171-R179)

These changes collectively improve modularity, testability, and dependency management in the feature modules. 