### PR TITLE
Chore/electron releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,116 @@
+name: Release Build
+
+on:
+  push:
+    branches: [ chore/electron-releases ]
+
+jobs:
+  build-linux:
+    name: Build Linux (.AppImage + .deb)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build Angular app
+        run: bunx ng build --configuration=production --base-href ./
+
+      - name: Compile Electron TypeScript
+        run: bun run electron:tsc
+
+      - name: Package with electron-builder (Linux)
+        run: bunx electron-builder --linux --publish never
+
+      - name: Upload Linux artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-artifacts
+          path: |
+            release/*.AppImage
+            release/*.deb
+          if-no-files-found: error
+
+  build-windows:
+    name: Build Windows (.exe)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build Angular app
+        run: bunx ng build --configuration=production --base-href ./
+
+      - name: Compile Electron TypeScript
+        run: bun run electron:tsc
+
+      - name: Package with electron-builder (Windows)
+        run: bunx electron-builder --win --publish never
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+
+      - name: Upload Windows artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-artifacts
+          path: |
+            release/**/*.exe
+            release/*.exe
+          if-no-files-found: error
+
+  publish:
+    name: Publish GitHub Release
+    needs: [ build-linux, build-windows ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Generate version tag and release name
+        id: version
+        run: |
+          DATE=$(date +'%Y%m%d')
+          DISPLAY_DATE=$(date +'%Y-%m-%d')
+          TAG="alpha-${DATE}-${{ github.run_number }}"
+          NAME="Alpha ${DISPLAY_DATE} (Build #${{ github.run_number }})"
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "name=${NAME}" >> $GITHUB_OUTPUT
+
+      - name: Download Linux artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-artifacts
+          path: dist/linux
+
+      - name: Download Windows artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-artifacts
+          path: dist/windows
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: ${{ steps.version.outputs.name }}
+          prerelease: true
+          generate_release_notes: true
+          files: |
+            dist/linux/*.AppImage
+            dist/linux/*.deb
+            dist/windows/**/*.exe
+            dist/windows/*.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release Build
 
 on:
   push:
-    branches: [ chore/electron-releases ]
+    branches: [ main ]
 
 jobs:
   build-linux:

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
       "target": "dmg"
     },
     "linux": {
-      "target": "AppImage"
+      "target": ["AppImage", "deb"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "twdist-desktop",
   "version": "0.0.0",
+  "description": "TWDist Desktop Application",
   "main": "dist-electron/main.js",
   "scripts": {
     "ng": "ng",
@@ -62,7 +63,8 @@
       "target": "dmg"
     },
     "linux": {
-      "target": ["AppImage", "deb"]
+      "target": ["AppImage", "deb"],
+      "maintainer": "David M. <davmunher@users.noreply.github.com>, Oscar Barber <oscbarcan@users.noreply.github.com>"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,14 +27,14 @@
     "@types/node": "^24.12.0",
     "concurrently": "^9.2.1",
     "cross-env": "^10.1.0",
-    "electron": "^39.8.2",
-    "electron-builder": "^26.8.1",
     "rxjs": "~7.8.2",
     "tslib": "^2.8.1",
     "wait-on": "^9.0.4"
   },
   "devDependencies": {
     "@analogjs/vite-plugin-angular": "^2.3.1",
+    "electron": "^39.8.2",
+    "electron-builder": "^26.8.1",
     "@angular-devkit/build-angular": "^20.3.20",
     "@angular/cli": "^20.3.20",
     "@angular/compiler-cli": "^20.3.18",


### PR DESCRIPTION
Added main pipeline for creating automatic tag and release when pushing into main.

You can already see an example of how this look like on the first release of the repo.

Many changes have to be done so that these releases actually work. I will be checking all the errors with the AppImage releases and make PRs accordingly to solve this.