### PR TITLE
Refactor/auth management

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -4,6 +4,7 @@ import { provideHttpClient, withInterceptors } from '@angular/common/http';
 
 import { routes } from './app.routes';
 import { PROJECT_FEATURE_PROVIDERS } from '@features/projects/projects.providers';
+import { authInterceptor } from '@shared/interceptors/auth.interceptor';
 import { baseUrlInterceptor } from '@shared/interceptors/base-url.interceptor';
 import { credentialsInterceptor } from '@shared/interceptors/credentials.interceptor';
 import { errorInterceptor } from '@shared/interceptors/error.interceptor';
@@ -12,24 +13,30 @@ import { AUTH_FEATURE_PROVIDERS } from '@features/auth/auth.providers';
 import { AuthStore } from '@features/auth/presentation/store/auth.store';
 import { TODAY_FEATURE_PROVIDERS } from '@features/today/today.providers';
 import { UPCOMING_FEATURE_PROVIDERS } from '@features/upcoming/upcoming.providers';
+import { RuntimeConfigService } from '@shared/config/runtime-config.service';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZonelessChangeDetection(),
     provideRouter(routes, withHashLocation()),
     provideHttpClient(
-      withInterceptors([baseUrlInterceptor, credentialsInterceptor, errorInterceptor, refreshTokenInterceptor])
+      withInterceptors([
+        baseUrlInterceptor,
+        authInterceptor,
+        credentialsInterceptor,
+        errorInterceptor,
+        refreshTokenInterceptor,
+      ])
     ),
     ...PROJECT_FEATURE_PROVIDERS,
     ...AUTH_FEATURE_PROVIDERS,
     ...TODAY_FEATURE_PROVIDERS,
     ...UPCOMING_FEATURE_PROVIDERS,
 
-    // Check authentication status on app startup
-    // This validates the cookie with the backend and updates the auth state
-    // Error handling ensures the app doesn't hang if the cookie is invalid
-    provideAppInitializer(() => {
+    provideAppInitializer(async () => {
+      const runtimeConfig = inject(RuntimeConfigService);
       const authStore = inject(AuthStore);
+      await runtimeConfig.load();
       return authStore.checkAuthStatus();
     }),
   ],

--- a/src/app/features/auth/application/services/token-refresh-coordinator.service.ts
+++ b/src/app/features/auth/application/services/token-refresh-coordinator.service.ts
@@ -3,6 +3,7 @@ import { BehaviorSubject, Observable, catchError, finalize, shareReplay, tap, th
 
 import { RefreshSessionUseCase } from '@features/auth/application/use-cases/refresh-session.use-case';
 import { SessionHintService } from '@features/auth/infrastructure/services/session-hint.service';
+import { TokenService } from '@features/auth/infrastructure/services/token.service';
 import { AuthStore } from '@features/auth/presentation/store/auth.store';
 
 export type RefreshState = 'idle' | 'refreshing' | { error: unknown };
@@ -11,6 +12,7 @@ export type RefreshState = 'idle' | 'refreshing' | { error: unknown };
 export class TokenRefreshCoordinator {
   private readonly refreshSessionUseCase = inject(RefreshSessionUseCase);
   private readonly sessionHintService = inject(SessionHintService);
+  private readonly tokenService = inject(TokenService);
   private readonly authStore = inject(AuthStore);
   private inFlightRefresh$: Observable<void> | null = null;
 
@@ -34,6 +36,7 @@ export class TokenRefreshCoordinator {
       }),
       catchError((error: unknown) => {
         this.sessionHintService.clear();
+        this.tokenService.clear();
         this.authStore.clearSessionState();
         this.state.next({ error });
 

--- a/src/app/features/auth/infrastructure/dto/response/auth-response.dto.ts
+++ b/src/app/features/auth/infrastructure/dto/response/auth-response.dto.ts
@@ -1,5 +1,7 @@
 import { UserResponseDto } from "@features/auth/infrastructure/dto/response/user-response.dto";
 
 export interface AuthResponseDto {
-  user: UserResponseDto; 
+  user: UserResponseDto;
+  accessToken?: string;
+  refreshToken?: string;
 }

--- a/src/app/features/auth/infrastructure/repositories/http-auth.repository.ts
+++ b/src/app/features/auth/infrastructure/repositories/http-auth.repository.ts
@@ -11,6 +11,7 @@ import { RegisterCredentialsDto } from "@features/auth/infrastructure/dto/reques
 import { UpdateUsernameDto } from "@features/auth/infrastructure/dto/request/update-username.dto";
 import { UpdatePasswordDto } from "@features/auth/infrastructure/dto/request/update-password.dto";
 import { SessionHintService } from "@features/auth/infrastructure/services/session-hint.service";
+import { TokenService } from "@features/auth/infrastructure/services/token.service";
 import { requiresAuthContext } from "@shared/interceptors/auth-context.token";
 import { AuthError } from "@features/auth/domain/errors/auth.error";
 
@@ -18,11 +19,12 @@ import { AuthError } from "@features/auth/domain/errors/auth.error";
 export class HttpAuthRepository extends AuthRepository {
   private http = inject(HttpClient);
   private sessionHintService = inject(SessionHintService);
-
+  private tokenService = inject(TokenService);
 
   login(credentials: LoginCredentialsDto): Observable<User> {
     return this.http.post<AuthResponseDto>('/auth/login', credentials)
       .pipe(
+        tap((dto) => this.persistTokens(dto)),
         map(dto => {
           if (!dto?.user?.id) {
             throw new AuthError('INVALID_LOGIN_RESPONSE', 'Invalid login response: missing user data');
@@ -30,8 +32,6 @@ export class HttpAuthRepository extends AuthRepository {
           return UserMapper.toDomain(dto.user);
         }),
         tap(() => this.sessionHintService.markAuthenticated()),
-        // `unknown` is intentional here: RxJS error channels can contain any value,
-        // so we narrow explicitly (`instanceof`) before reading error details.
         catchError((error: unknown) => {
           if (error instanceof HttpErrorResponse && error.status === 401) {
             return throwError(() => new AuthError('INVALID_CREDENTIALS', 'Invalid email or password'));
@@ -47,7 +47,12 @@ export class HttpAuthRepository extends AuthRepository {
   }
 
   refresh(): Observable<void> {
-    return this.http.post<unknown>('/auth/refresh', {}).pipe(
+    const body = this.tokenService.isBearerAuthEnabled()
+      ? { refreshToken: this.tokenService.getRefreshToken() ?? '' }
+      : {};
+
+    return this.http.post<AuthResponseDto>('/auth/refresh', body).pipe(
+      tap((dto) => this.persistTokens(dto)),
       map(() => void 0),
       catchError((error: unknown) => {
         if (error instanceof HttpErrorResponse && error.status === 401) {
@@ -72,12 +77,10 @@ export class HttpAuthRepository extends AuthRepository {
   }
 
   logout(): Observable<void> {
-    // Server clears the cookie
     return this.http.post<void>('/auth/logout', {}, requiresAuthContext()).pipe(
-      tap(() => this.sessionHintService.clear()),
+      tap(() => this.clearLocalSession()),
       catchError(() => {
-        // Even if the server fails, clear local session hint
-        this.sessionHintService.clear();
+        this.clearLocalSession();
         return of(void 0);
       })
     );
@@ -92,8 +95,7 @@ export class HttpAuthRepository extends AuthRepository {
       .pipe(
         map(dto => UserMapper.toDomain(dto)),
         catchError(() => {
-          // If cookie expired or unauthorized, clear the session hint
-          this.sessionHintService.clear();
+          this.clearLocalSession();
           return of(null)
         })
       );
@@ -128,5 +130,21 @@ export class HttpAuthRepository extends AuthRepository {
           return throwError(() => new AuthError('UNKNOWN_AUTH_ERROR', 'Unexpected error updating password'));
         })
       );
+  }
+
+  private persistTokens(dto: AuthResponseDto): void {
+    if (!dto.accessToken || !dto.refreshToken) {
+      return;
+    }
+
+    this.tokenService.save({
+      accessToken: dto.accessToken.replace(/^Bearer\s+/i, '').trim(),
+      refreshToken: dto.refreshToken.replace(/^Bearer\s+/i, '').trim(),
+    });
+  }
+
+  private clearLocalSession(): void {
+    this.sessionHintService.clear();
+    this.tokenService.clear();
   }
 }

--- a/src/app/features/auth/infrastructure/services/token.service.ts
+++ b/src/app/features/auth/infrastructure/services/token.service.ts
@@ -1,0 +1,53 @@
+import { Injectable, inject } from '@angular/core';
+import { RuntimeConfigService } from '@shared/config/runtime-config.service';
+
+const ACCESS_TOKEN_KEY = 'twdist_access_token';
+const REFRESH_TOKEN_KEY = 'twdist_refresh_token';
+
+export interface StoredTokens {
+  accessToken: string;
+  refreshToken: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class TokenService {
+  private readonly runtimeConfig = inject(RuntimeConfigService);
+
+  isBearerAuthEnabled(): boolean {
+    return this.runtimeConfig.isBearerAuthEnabled();
+  }
+
+  save(tokens: StoredTokens): void {
+    if (!this.isBearerAuthEnabled()) {
+      return;
+    }
+
+    localStorage.setItem(ACCESS_TOKEN_KEY, tokens.accessToken);
+    localStorage.setItem(REFRESH_TOKEN_KEY, tokens.refreshToken);
+  }
+
+  getAccessToken(): string | null {
+    if (!this.isBearerAuthEnabled()) {
+      return null;
+    }
+
+    return localStorage.getItem(ACCESS_TOKEN_KEY);
+  }
+
+  getRefreshToken(): string | null {
+    if (!this.isBearerAuthEnabled()) {
+      return null;
+    }
+
+    return localStorage.getItem(REFRESH_TOKEN_KEY);
+  }
+
+  clear(): void {
+    if (!this.isBearerAuthEnabled()) {
+      return;
+    }
+
+    localStorage.removeItem(ACCESS_TOKEN_KEY);
+    localStorage.removeItem(REFRESH_TOKEN_KEY);
+  }
+}

--- a/src/app/shared/config/environment.electron-local.ts
+++ b/src/app/shared/config/environment.electron-local.ts
@@ -1,0 +1,6 @@
+// Local packaged Electron preview (file://) — API URL comes from electron/config.local.json.
+export const environment = {
+  production: true,
+  apiBaseUrl: '',
+  isElectronRelease: true,
+};

--- a/src/app/shared/config/environment.prod.ts
+++ b/src/app/shared/config/environment.prod.ts
@@ -1,0 +1,7 @@
+// Production Angular build for packaged Electron (file://).
+// apiBaseUrl is injected at runtime via resources/config.json (see scripts/write-electron-config.mjs).
+export const environment = {
+  production: true,
+  apiBaseUrl: '',
+  isElectronRelease: true,
+};

--- a/src/app/shared/config/environment.ts
+++ b/src/app/shared/config/environment.ts
@@ -7,4 +7,6 @@ const API_BASE_URL = '/api';
 export const environment = {
   production: false,
   apiBaseUrl: API_BASE_URL,
+  /** When true, use Bearer tokens instead of cookie-based auth (Electron packaged builds). */
+  isElectronRelease: false,
 };

--- a/src/app/shared/config/runtime-config.service.ts
+++ b/src/app/shared/config/runtime-config.service.ts
@@ -1,0 +1,83 @@
+import { Injectable } from '@angular/core';
+import { environment } from '@shared/config/environment';
+
+export interface ElectronAppConfig {
+  apiBaseUrl: string;
+  useBearerAuth?: boolean;
+}
+
+export interface ResolvedRuntimeConfig {
+  apiBaseUrl: string;
+  isBearerAuthEnabled: boolean;
+}
+
+@Injectable({ providedIn: 'root' })
+export class RuntimeConfigService {
+  private config: ResolvedRuntimeConfig;
+
+  constructor() {
+    this.config = this.buildInitialConfig();
+  }
+
+  get apiBaseUrl(): string {
+    return this.config.apiBaseUrl;
+  }
+
+  isBearerAuthEnabled(): boolean {
+    return this.config.isBearerAuthEnabled;
+  }
+
+  /** Loads Electron-side config when running inside the desktop shell. */
+  async load(): Promise<void> {
+    const syncConfig = this.getSyncElectronConfig();
+    if (syncConfig?.apiBaseUrl) {
+      this.config = this.configFromElectron(syncConfig);
+      return;
+    }
+
+    if (typeof window === 'undefined' || !window.electronAPI?.getAppConfig) {
+      return;
+    }
+
+    const electronConfig = await window.electronAPI.getAppConfig();
+    if (!electronConfig?.apiBaseUrl) {
+      if (environment.isElectronRelease) {
+        console.error(
+          '[RuntimeConfig] Missing electron/config.local.json (or packaged config.json). ' +
+            'Copy electron/config.example.json and set apiBaseUrl.',
+        );
+      }
+      return;
+    }
+
+    this.config = this.configFromElectron(electronConfig);
+  }
+
+  private buildInitialConfig(): ResolvedRuntimeConfig {
+    const syncConfig = this.getSyncElectronConfig();
+    if (syncConfig?.apiBaseUrl) {
+      return this.configFromElectron(syncConfig);
+    }
+
+    return {
+      apiBaseUrl: environment.apiBaseUrl,
+      isBearerAuthEnabled: environment.isElectronRelease,
+    };
+  }
+
+  private getSyncElectronConfig(): ElectronAppConfig | null {
+    if (typeof window === 'undefined') {
+      return null;
+    }
+
+    return window.__electronRuntimeConfig ?? null;
+  }
+
+  private configFromElectron(electronConfig: ElectronAppConfig): ResolvedRuntimeConfig {
+    return {
+      apiBaseUrl: electronConfig.apiBaseUrl,
+      isBearerAuthEnabled:
+        electronConfig.useBearerAuth ?? environment.isElectronRelease,
+    };
+  }
+}

--- a/src/app/shared/interceptors/auth-url.util.ts
+++ b/src/app/shared/interceptors/auth-url.util.ts
@@ -1,0 +1,16 @@
+/** Auth endpoints that must not carry an access-token Bearer header. */
+const BEARER_EXCLUDED_AUTH_PATHS = ['/auth/refresh', '/auth/login', '/auth/signup'];
+
+export function isBearerExcludedAuthUrl(url: string): boolean {
+  const path = stripQueryString(stripOrigin(url));
+
+  return BEARER_EXCLUDED_AUTH_PATHS.some((authPath) => path.endsWith(authPath));
+}
+
+function stripOrigin(url: string): string {
+  return url.replace(/^https?:\/\/[^/]+/u, '');
+}
+
+function stripQueryString(url: string): string {
+  return url.split('?')[0] ?? url;
+}

--- a/src/app/shared/interceptors/auth.interceptor.ts
+++ b/src/app/shared/interceptors/auth.interceptor.ts
@@ -1,0 +1,25 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+
+import { TokenService } from '@features/auth/infrastructure/services/token.service';
+import { isBearerExcludedAuthUrl } from '@shared/interceptors/auth-url.util';
+
+/**
+ * Attaches `Authorization: Bearer <accessToken>` when running an Electron release
+ * build with tokens stored in localStorage.
+ */
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const accessToken = inject(TokenService).getAccessToken();
+
+  if (!accessToken || isBearerExcludedAuthUrl(req.url)) {
+    return next(req);
+  }
+
+  return next(
+    req.clone({
+      setHeaders: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    }),
+  );
+};

--- a/src/app/shared/interceptors/base-url.interceptor.ts
+++ b/src/app/shared/interceptors/base-url.interceptor.ts
@@ -1,16 +1,33 @@
 import { HttpInterceptorFn } from '@angular/common/http';
-import { environment } from '@shared/config/environment';
+import { inject } from '@angular/core';
 
+import { environment } from '@shared/config/environment';
+import { RuntimeConfigService } from '@shared/config/runtime-config.service';
 
 export const baseUrlInterceptor: HttpInterceptorFn = (req, next) => {
-  // Check if the request already has a full URL
   if (req.url.startsWith('http://') || req.url.startsWith('https://')) {
     return next(req);
   }
 
-  // Clone the request and add the base URL
+  const baseUrl = inject(RuntimeConfigService).apiBaseUrl;
+
+  if (!baseUrl) {
+    throw new Error(
+      'API base URL is not configured. For Electron, create electron/config.local.json (see config.example.json).',
+    );
+  }
+
+  const isAbsolute = baseUrl.startsWith('http://') || baseUrl.startsWith('https://');
+  const isDevProxyPath = baseUrl.startsWith('/') && !environment.isElectronRelease;
+
+  if (!isAbsolute && !isDevProxyPath) {
+    throw new Error(
+      `API base URL must be absolute (http/https) in Electron builds. Got "${baseUrl}".`,
+    );
+  }
+
   const baseUrlReq = req.clone({
-    url: `${environment.apiBaseUrl}${req.url}`,
+    url: `${baseUrl.replace(/\/$/, '')}${req.url}`,
   });
 
   return next(baseUrlReq);

--- a/src/app/shared/interceptors/credentials.interceptor.ts
+++ b/src/app/shared/interceptors/credentials.interceptor.ts
@@ -1,23 +1,20 @@
 import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+
+import { TokenService } from '@features/auth/infrastructure/services/token.service';
 
 /**
- * Credentials Interceptor
- * Automatically sends HTTP-only cookies with all requests
- * 
- * This interceptor adds `withCredentials: true` to all outgoing requests,
- * which tells the browser to include any HTTP-only cookies in the request.
- * This is essential for cookie-based authentication where the auth token
- * is stored in an HTTP-only cookie (set by the server during login).
- * 
- * The HTTP-only flag prevents JavaScript from accessing the cookie,
- * protecting against XSS attacks while still allowing it to be sent
- * automatically with each request.
+ * Sends HTTP-only cookies with requests in browser/dev (proxy) mode.
+ * Skipped when Bearer auth is enabled (Electron release).
  */
 export const credentialsInterceptor: HttpInterceptorFn = (req, next) => {
-  // Clone the request and enable credentials (cookies)
-  const credentializedReq = req.clone({
-    withCredentials: true,
-  });
+  if (inject(TokenService).isBearerAuthEnabled()) {
+    return next(req);
+  }
 
-  return next(credentializedReq);
+  return next(
+    req.clone({
+      withCredentials: true,
+    }),
+  );
 };

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -1,10 +1,18 @@
+export interface ElectronAppConfig {
+  apiBaseUrl: string;
+  useBearerAuth?: boolean;
+}
+
 export interface IElectronAPI {
+  getAppConfig?: () => Promise<ElectronAppConfig | null>;
   sendMessage: (msg: string) => void;
   onResponse: (callback: (response: unknown) => void) => void;
 }
 
 declare global {
   interface Window {
-    electronAPI: IElectronAPI;
+    electronAPI?: IElectronAPI;
+    /** Set synchronously by Electron preload when the shell injects config. */
+    __electronRuntimeConfig?: ElectronAppConfig;
   }
 }


### PR DESCRIPTION
I basically changed the auth system to accept only bearer tokens in the Desktop app.

This was for testing and ensuring that the auth system was working properly both in dev and prod modes.

Basically, this is a temporary fix. I will make some changes for this system in a future PR to allow storing the access token in memory (not localStorage) and the refresh token in a HtppOnly cookie for the web app. The electron-based desktop app will then move to the refresh token being stored in the key store of the system using keytar. The AT will be stored in the main process memory. This is the safest approach.

But for now, that is out of scope. This PR will first need to be accepted and then I will refactor the auth flow to adapt to these best practices.

---

AI Summary:
This pull request introduces support for Bearer token authentication for Electron builds, while maintaining cookie-based authentication for browser and development environments. The implementation includes a new `TokenService` for managing tokens in localStorage, runtime configuration for determining the authentication mode, and updates to HTTP interceptors and authentication flows. The most important changes are grouped below:

**Authentication Mode & Runtime Configuration**

* Added `RuntimeConfigService` to dynamically determine at runtime whether to use Bearer token or cookie-based authentication, based on environment and Electron-specific config files. (`src/app/shared/config/runtime-config.service.ts`)
* Updated environment files to include an `isElectronRelease` flag for distinguishing Electron builds. (`src/app/shared/config/environment.ts`, `src/app/shared/config/environment.electron-local.ts`, `src/app/shared/config/environment.prod.ts`) [[1]](diffhunk://#diff-9466436a2e54ef77bce70609c822e05225adc99f867d098a7de98fb47d116724R10-R11) [[2]](diffhunk://#diff-7129724e0b992a1d09a3114e0574aa75166c62e6e87fb086fb0dee79154acd20R1-R6) [[3]](diffhunk://#diff-a0316bd2eec94740ce566135dadd11e6c9b24ad38e77312b10972c050b8cb149R1-R7)

**Token Management**

* Introduced `TokenService` for storing, retrieving, and clearing access and refresh tokens in localStorage when Bearer auth is enabled. (`src/app/features/auth/infrastructure/services/token.service.ts`)
* Updated `AuthResponseDto` to optionally include `accessToken` and `refreshToken` fields. (`src/app/features/auth/infrastructure/dto/response/auth-response.dto.ts`)

**HTTP Interceptors**

* Added a new `authInterceptor` to attach the `Authorization: Bearer <accessToken>` header to outgoing requests when Bearer auth is active, excluding certain authentication endpoints. (`src/app/shared/interceptors/auth.interceptor.ts`, `src/app/shared/interceptors/auth-url.util.ts`) [[1]](diffhunk://#diff-749fd1bf7e0f265353d0b989f735ed004b628c243d207ffc26668f15b081ed48R1-R25) [[2]](diffhunk://#diff-fcd72d8c461340a854f2df7696cbe920451f3e71bd8136ad97124de46a5ed518R1-R16)
* Modified `credentialsInterceptor` to skip adding cookies when Bearer auth is enabled. (`src/app/shared/interceptors/credentials.interceptor.ts`)
* Updated `baseUrlInterceptor` to use runtime-configured API base URL and validate its format, improving support for both Electron and dev environments. (`src/app/shared/interceptors/base-url.interceptor.ts`)

**Authentication Flow Updates**

* Updated `HttpAuthRepository` to persist tokens on login and refresh, send refresh tokens in the request body when Bearer auth is enabled, and clear tokens on logout or session errors. (`src/app/features/auth/infrastructure/repositories/http-auth.repository.ts`) [[1]](diffhunk://#diff-f969916ea5c0159ed106bbc6f0cf359fd3ce97af9dd91ea0f667203d5a79ad60R14-L34) [[2]](diffhunk://#diff-f969916ea5c0159ed106bbc6f0cf359fd3ce97af9dd91ea0f667203d5a79ad60L50-R55) [[3]](diffhunk://#diff-f969916ea5c0159ed106bbc6f0cf359fd3ce97af9dd91ea0f667203d5a79ad60L75-R83) [[4]](diffhunk://#diff-f969916ea5c0159ed106bbc6f0cf359fd3ce97af9dd91ea0f667203d5a79ad60L95-R98) [[5]](diffhunk://#diff-f969916ea5c0159ed106bbc6f0cf359fd3ce97af9dd91ea0f667203d5a79ad60R134-R149)
* Updated `TokenRefreshCoordinator` to clear tokens on refresh errors. (`src/app/features/auth/application/services/token-refresh-coordinator.service.ts`) [[1]](diffhunk://#diff-dc830cefc0d643af43fc880f0cf8226387fa3edef3ceb0932b555308b06ec9fdR6) [[2]](diffhunk://#diff-dc830cefc0d643af43fc880f0cf8226387fa3edef3ceb0932b555308b06ec9fdR15) [[3]](diffhunk://#diff-dc830cefc0d643af43fc880f0cf8226387fa3edef3ceb0932b555308b06ec9fdR39)

**App Initialization**

* Modified app initialization to load runtime config before checking authentication status, ensuring the correct authentication mode is set on startup. (`src/app/app.config.ts`) [[1]](diffhunk://#diff-fff0e6dc5626f82b3c71292d91384f36da38d5437a8ed1946eb9b903505ac035R7) [[2]](diffhunk://#diff-fff0e6dc5626f82b3c71292d91384f36da38d5437a8ed1946eb9b903505ac035R16-R39)