### PR TITLE
Fix/reload page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,27 @@
 # Contributing
 
+## Running the app locally
+
+See **[docs/local-development.md](docs/local-development.md)** for:
+
+- Web dev (`ng serve`) against a local backend
+- Electron dev (`bun run start`) with `electron/config.local.json`
+- Electron preview (`bun run electron:preview`) — production-like shell
+- Testing against a **remote / production API** from your machine (without committing URLs)
+- Building installers locally with `TWDIST_API_BASE_URL`
+
+Never commit `electron/config.local.json` or `electron/config.packaged.json`.
+
+## CI before opening a PR
+
+```bash
+bunx ng test --watch=false
+bun run lint
+bunx ng build --configuration=production --progress=false
+```
+
+Or run the full workflow locally: `act -W .github/workflows/ci.yml -j build-and-test` (requires [act](https://github.com/nektos/act)).
+
 ## Opening a Pull Request with a Specific Template
 Click below to open a PR with the correct template:
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,17 @@ npm install
 bun install
 ```
 
-## Start developing!
-For starting developing in this project you can just run `bun run start` and it will automatically start a new Electron app with the content of the Angular app.
+## Start developing
+
+**Quick start (Electron + hot reload):**
+
+```sh
+cp electron/config.example.json electron/config.local.json   # once — edit apiBaseUrl if needed
+bun run start
+```
+
+**Contributor guide** (web vs Electron, local vs production API, preview & packaged builds):  
+[docs/local-development.md](docs/local-development.md)
 
 ## Testing templates
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,198 @@
+# Running TWDist Desktop locally
+
+This guide explains how to run the app against a **local backend** or a **remote production-like API**, using the web dev server or the Electron shell.
+
+## Prerequisites
+
+- [Bun](https://bun.sh) or Node.js 20+ and npm
+- Dependencies installed: `bun install`
+- A running **TWDist backend** (local JAR on port `8080`, or a deployed Cloud Run URL)
+- For Electron: native build tools may be required on Linux (`rpm`, `dpkg`, etc.) when packaging only
+
+## Runtime configuration (Electron)
+
+Electron does **not** bake the API URL into the Angular bundle. Settings come from a JSON file at runtime:
+
+| File | Committed? | Used when |
+|------|------------|-----------|
+| `electron/config.example.json` | Yes | Template — copy this |
+| `electron/config.local.json` | **No** (gitignored) | Local dev & preview on your machine |
+| `electron/config.packaged.json` | **No** (gitignored) | Generated before `electron:build` |
+| `resources/config.json` (inside installer) | N/A | Packaged app at install time |
+
+Create your local config once:
+
+```bash
+cp electron/config.example.json electron/config.local.json
+```
+
+Example for a **local backend**:
+
+```json
+{
+  "apiBaseUrl": "http://localhost:8080/api",
+  "useBearerAuth": true
+}
+```
+
+Example for a **remote / production API** (test prod from your machine):
+
+```json
+{
+  "apiBaseUrl": "https://YOUR_CLOUD_RUN_HOST.run.app/api",
+  "useBearerAuth": true
+}
+```
+
+Use an **absolute** `http://` or `https://` URL in Electron preview and packaged builds. The dev-server proxy (`/api`) only applies when Angular runs on `http://localhost:4200`.
+
+---
+
+## Quick reference
+
+| Goal | Command | API config | Auth |
+|------|---------|------------|------|
+| Web UI + local API | `bunx ng serve` | `proxy.conf.json` → `localhost:8080` | Cookies (browser) |
+| Electron + hot reload | `bun run start` | `electron/config.local.json` | Bearer tokens |
+| Electron, packaged-like UI | `bun run electron:preview` | `electron/config.local.json` | Bearer tokens |
+| Installer / AppImage locally | See [Packaged build](#packaged-build-production-api-locally) | `TWDIST_API_BASE_URL` env | Bearer tokens |
+
+---
+
+## 1. Web app + local backend (browser)
+
+Best for UI work with cookie-based auth (same as classic web deployment).
+
+1. Start the backend on `http://localhost:8080`.
+2. From this repo:
+
+   ```bash
+   bunx ng serve
+   ```
+
+3. Open `http://localhost:4200`.
+
+Requests to `/api/*` are proxied to the backend via `proxy.conf.json`. No `config.local.json` is required.
+
+**Do not** commit changes to `src/app/shared/config/environment.ts` that hardcode a production URL; keep `apiBaseUrl: '/api'` for this mode.
+
+---
+
+## 2. Electron dev (hot reload)
+
+Default `bun run start` runs the Angular dev server and opens an Electron window pointed at `http://localhost:4200`.
+
+1. Ensure `electron/config.local.json` exists (see above).
+2. Start the backend (local or remote, matching `apiBaseUrl` in your config).
+3. Run:
+
+   ```bash
+   bun run start
+   ```
+
+Electron injects config via preload (`__electronRuntimeConfig`). HTTP calls use the URL from config; SSE resolves `/api` against `http://localhost:4200` when the dev server is used.
+
+**Tip:** After changing `config.local.json`, restart `bun run start`.
+
+---
+
+## 3. Electron preview (production-like shell)
+
+Simulates the packaged app (`app://` protocol, production Angular build, Bearer auth). Use this before opening a PR that touches Electron or auth.
+
+1. Set `electron/config.local.json` with an **absolute** `apiBaseUrl`.
+2. Run:
+
+   ```bash
+   bun run electron:preview
+   ```
+
+This runs `ng build --configuration=electron-local`, compiles Electron TypeScript, and starts Electron with `NODE_ENV=production`.
+
+**Checklist:**
+
+- Login works
+- Reload keeps the session (refresh token flow)
+- Project list and SSE (user/project events) connect without console errors
+
+---
+
+## 4. Local app against production API
+
+To debug against the **live backend** without deploying the desktop app:
+
+1. Copy `electron/config.example.json` → `electron/config.local.json` if needed.
+2. Set `apiBaseUrl` to your production API base (including `/api` path), e.g.  
+   `https://twdist-back-….run.app/api`
+3. Keep `"useBearerAuth": true`.
+4. Run either:
+   - `bun run start` — faster iteration (dev server + Electron), or
+   - `bun run electron:preview` — closer to what users install
+
+**Security:** Do not commit `config.local.json` or paste production secrets into the repo. The URL alone is usually enough; auth uses your normal login.
+
+**Backend:** Production must issue `accessToken` / `refreshToken` on login and refresh (Bearer flow). Cookie-only auth is not sufficient for packaged Electron.
+
+---
+
+## 5. Packaged build (production API locally)
+
+To build an `.AppImage` / `.deb` / `.exe` on your machine pointing at a specific API:
+
+```bash
+export TWDIST_API_BASE_URL="https://YOUR_API_HOST.run.app/api"
+bun run electron:build
+```
+
+`electron:config` writes `electron/config.packaged.json` (gitignored). `electron-builder` bundles it as `resources/config.json` inside the installer.
+
+Artifacts appear under `release/`.
+
+**CI note:** GitHub Actions release workflow should set `TWDIST_API_BASE_URL` from a repository secret and run `bun run electron:config` before `electron-builder` so installers include the correct API URL. That secret is not stored in git.
+
+---
+
+## Auth behavior by mode
+
+| Mode | Session storage | Refresh on 401 |
+|------|-----------------|----------------|
+| `ng serve` (browser) | HTTP-only cookies + `has_session` hint | Cookie refresh |
+| Electron (`useBearerAuth: true`) | `localStorage` access/refresh tokens | `POST /auth/refresh` with refresh token body |
+
+---
+
+## Verification before a PR
+
+```bash
+# Unit tests + lint (same as CI)
+bunx ng test --watch=false
+bun run lint
+bunx ng build --configuration=production --progress=false
+
+# Optional: full CI locally
+act -W .github/workflows/ci.yml -j build-and-test
+```
+
+Manually verify the path you changed (browser dev, `electron:preview`, or both).
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|----------------|
+| Immediate redirect to login after reload | Session bootstrap / refresh; ensure `config.local.json` is loaded and backend returns tokens on refresh |
+| `SSE requires an absolute API base URL` | Electron preview without config, or missing `apiBaseUrl` in `config.local.json` |
+| `API base URL is not configured` | No `config.local.json` for Electron preview/packaged build |
+| Login works in browser but not Electron | Backend Bearer tokens disabled or wrong `apiBaseUrl` |
+| CORS errors in browser | Backend CORS / proxy; use `ng serve` proxy, not a hardcoded remote URL in `environment.ts` |
+
+---
+
+## Related files
+
+- `proxy.conf.json` — web dev proxy
+- `src/app/shared/config/environment.ts` — web defaults (`/api`)
+- `src/app/shared/config/environment.electron-local.ts` — Electron preview build flags
+- `src/app/shared/config/environment.prod.ts` — packaged Angular build (empty `apiBaseUrl`; filled at runtime)
+- `scripts/write-electron-config.mjs` — generates packaged config from `TWDIST_API_BASE_URL`

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,6 +1,7 @@
 import { ApplicationConfig, inject, provideAppInitializer, provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter, withHashLocation } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
 
 import { routes } from './app.routes';
 import { PROJECT_FEATURE_PROVIDERS } from '@features/projects/projects.providers';
@@ -21,11 +22,11 @@ export const appConfig: ApplicationConfig = {
     provideRouter(routes, withHashLocation()),
     provideHttpClient(
       withInterceptors([
+        refreshTokenInterceptor,
         baseUrlInterceptor,
         authInterceptor,
         credentialsInterceptor,
         errorInterceptor,
-        refreshTokenInterceptor,
       ])
     ),
     ...PROJECT_FEATURE_PROVIDERS,
@@ -37,7 +38,9 @@ export const appConfig: ApplicationConfig = {
       const runtimeConfig = inject(RuntimeConfigService);
       const authStore = inject(AuthStore);
       await runtimeConfig.load();
-      return authStore.checkAuthStatus();
+      // Must await the auth check — returning the Observable from an async fn only
+      // resolves a Promise<Observable>, so bootstrap would finish before /auth/me.
+      await firstValueFrom(authStore.checkAuthStatus());
     }),
   ],
 };

--- a/src/app/features/auth/application/services/token-refresh-coordinator.service.spec.ts
+++ b/src/app/features/auth/application/services/token-refresh-coordinator.service.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
+import { Router } from '@angular/router';
 import { Subject, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -27,6 +28,7 @@ describe('TokenRefreshCoordinator', () => {
         TokenRefreshCoordinator,
         { provide: RefreshSessionUseCase, useValue: refreshSessionUseCaseMock },
         { provide: AuthStore, useValue: authStoreMock },
+        { provide: Router, useValue: { url: '/projects/upcoming', navigate: vi.fn() } },
       ],
     });
 

--- a/src/app/features/auth/application/services/token-refresh-coordinator.service.ts
+++ b/src/app/features/auth/application/services/token-refresh-coordinator.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, inject } from '@angular/core';
+import { Router } from '@angular/router';
 import { BehaviorSubject, Observable, catchError, finalize, shareReplay, tap, throwError } from 'rxjs';
 
 import { RefreshSessionUseCase } from '@features/auth/application/use-cases/refresh-session.use-case';
@@ -14,6 +15,7 @@ export class TokenRefreshCoordinator {
   private readonly sessionHintService = inject(SessionHintService);
   private readonly tokenService = inject(TokenService);
   private readonly authStore = inject(AuthStore);
+  private readonly router = inject(Router);
   private inFlightRefresh$: Observable<void> | null = null;
 
   readonly state = new BehaviorSubject<RefreshState>('idle');
@@ -39,6 +41,10 @@ export class TokenRefreshCoordinator {
         this.tokenService.clear();
         this.authStore.clearSessionState();
         this.state.next({ error });
+
+        if (this.router.url !== '/auth/login') {
+          this.router.navigate(['/auth/login']);
+        }
 
         return throwError(() => error);
       }),

--- a/src/app/features/auth/infrastructure/repositories/http-auth.repository.ts
+++ b/src/app/features/auth/infrastructure/repositories/http-auth.repository.ts
@@ -94,10 +94,7 @@ export class HttpAuthRepository extends AuthRepository {
     return this.http.get<UserResponseDto>('/auth/me', requiresAuthContext())
       .pipe(
         map(dto => UserMapper.toDomain(dto)),
-        catchError(() => {
-          this.clearLocalSession();
-          return of(null)
-        })
+        catchError(() => of(null)),
       );
   }
 
@@ -133,14 +130,26 @@ export class HttpAuthRepository extends AuthRepository {
   }
 
   private persistTokens(dto: AuthResponseDto): void {
-    if (!dto.accessToken || !dto.refreshToken) {
+    const accessToken = this.normalizeToken(
+      dto.accessToken ?? (dto as { access_token?: string }).access_token,
+    );
+    const refreshToken = this.normalizeToken(
+      dto.refreshToken ?? (dto as { refresh_token?: string }).refresh_token,
+    );
+
+    if (!accessToken || !refreshToken) {
       return;
     }
 
-    this.tokenService.save({
-      accessToken: dto.accessToken.replace(/^Bearer\s+/i, '').trim(),
-      refreshToken: dto.refreshToken.replace(/^Bearer\s+/i, '').trim(),
-    });
+    this.tokenService.save({ accessToken, refreshToken });
+  }
+
+  private normalizeToken(value: string | undefined): string | null {
+    if (!value) {
+      return null;
+    }
+
+    return value.replace(/^Bearer\s+/i, '').trim();
   }
 
   private clearLocalSession(): void {

--- a/src/app/features/auth/infrastructure/services/session-hint.service.spec.ts
+++ b/src/app/features/auth/infrastructure/services/session-hint.service.spec.ts
@@ -2,13 +2,22 @@ import { TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { beforeEach, afterEach, describe, it, expect } from 'vitest';
 import { SessionHintService } from './session-hint.service';
+import { TokenService } from './token.service';
+import { RuntimeConfigService } from '@shared/config/runtime-config.service';
 
 describe('SessionHintService', () => {
   let service: SessionHintService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()],
+      providers: [
+        provideZonelessChangeDetection(),
+        TokenService,
+        {
+          provide: RuntimeConfigService,
+          useValue: { isBearerAuthEnabled: () => false },
+        },
+      ],
     });
     service = TestBed.inject(SessionHintService);
     // Always start each test with a clean localStorage
@@ -67,6 +76,30 @@ describe('SessionHintService', () => {
 
     it('does not throw if there is no hint to clear', () => {
       expect(() => service.clear()).not.toThrow();
+    });
+  });
+
+  describe('hasSessionHint() with bearer auth', () => {
+    beforeEach(() => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          provideZonelessChangeDetection(),
+          TokenService,
+          {
+            provide: RuntimeConfigService,
+            useValue: { isBearerAuthEnabled: () => true },
+          },
+        ],
+      });
+      service = TestBed.inject(SessionHintService);
+      localStorage.clear();
+    });
+
+    it('returns true when a refresh token is stored even without has_session', () => {
+      localStorage.setItem('twdist_refresh_token', 'refresh-abc');
+
+      expect(service.hasSessionHint()).toBe(true);
     });
   });
 });

--- a/src/app/features/auth/infrastructure/services/session-hint.service.ts
+++ b/src/app/features/auth/infrastructure/services/session-hint.service.ts
@@ -1,10 +1,21 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
+
+import { TokenService } from '@features/auth/infrastructure/services/token.service';
 
 @Injectable({ providedIn: 'root' })
 export class SessionHintService {
   private readonly storageKey = 'has_session';
+  private readonly tokenService = inject(TokenService);
 
   hasSessionHint(): boolean {
+    if (this.tokenService.isBearerAuthEnabled()) {
+      return (
+        !!this.tokenService.getRefreshToken() ||
+        !!this.tokenService.getAccessToken() ||
+        !!localStorage.getItem(this.storageKey)
+      );
+    }
+
     return !!localStorage.getItem(this.storageKey);
   }
 

--- a/src/app/features/auth/infrastructure/services/token.service.ts
+++ b/src/app/features/auth/infrastructure/services/token.service.ts
@@ -14,14 +14,15 @@ export class TokenService {
   private readonly runtimeConfig = inject(RuntimeConfigService);
 
   isBearerAuthEnabled(): boolean {
-    return this.runtimeConfig.isBearerAuthEnabled();
+    if (this.runtimeConfig.isBearerAuthEnabled()) {
+      return true;
+    }
+
+    // Tokens in storage imply bearer mode even if runtime config is not ready yet.
+    return !!localStorage.getItem(ACCESS_TOKEN_KEY) || !!localStorage.getItem(REFRESH_TOKEN_KEY);
   }
 
   save(tokens: StoredTokens): void {
-    if (!this.isBearerAuthEnabled()) {
-      return;
-    }
-
     localStorage.setItem(ACCESS_TOKEN_KEY, tokens.accessToken);
     localStorage.setItem(REFRESH_TOKEN_KEY, tokens.refreshToken);
   }

--- a/src/app/features/auth/presentation/store/auth.store.refresh.integration.spec.ts
+++ b/src/app/features/auth/presentation/store/auth.store.refresh.integration.spec.ts
@@ -19,6 +19,8 @@ import { HttpAuthRepository } from '@features/auth/infrastructure/repositories/h
 import { errorInterceptor } from '@shared/interceptors/error.interceptor';
 import { refreshTokenInterceptor } from '@shared/interceptors/refresh-token.interceptor';
 import { UserResponseDto } from '@features/auth/infrastructure/dto/response/user-response.dto';
+import { RuntimeConfigService } from '@shared/config/runtime-config.service';
+import { authInterceptor } from '@shared/interceptors/auth.interceptor';
 
 const USER_DTO: UserResponseDto = {
   id: 1,
@@ -27,56 +29,134 @@ const USER_DTO: UserResponseDto = {
 };
 
 describe('AuthStore refresh integration', () => {
-  let store: AuthStore;
-  let httpMock: HttpTestingController;
+  describe('cookie auth', () => {
+    let store: AuthStore;
+    let httpMock: HttpTestingController;
 
-  beforeEach(() => {
-    localStorage.clear();
+    beforeEach(() => {
+      localStorage.clear();
 
-    TestBed.configureTestingModule({
-      providers: [
-        provideZonelessChangeDetection(),
-        provideHttpClient(withInterceptors([errorInterceptor, refreshTokenInterceptor])),
-        provideHttpClientTesting(),
-        AuthStore,
-        LoginUseCase,
-        LogoutUseCase,
-        CreateUserUseCase,
-        GetCurrentUserUseCase,
-        UpdateUsernameUseCase,
-        UpdatePasswordUseCase,
-        RefreshSessionUseCase,
-        TokenRefreshCoordinator,
-        { provide: AuthRepository, useClass: HttpAuthRepository },
-        { provide: Router, useValue: { url: '/projects/upcoming', navigate: vi.fn() } },
-      ],
+      TestBed.configureTestingModule({
+        providers: [
+          provideZonelessChangeDetection(),
+          provideHttpClient(withInterceptors([refreshTokenInterceptor, authInterceptor, errorInterceptor])),
+          provideHttpClientTesting(),
+          AuthStore,
+          LoginUseCase,
+          LogoutUseCase,
+          CreateUserUseCase,
+          GetCurrentUserUseCase,
+          UpdateUsernameUseCase,
+          UpdatePasswordUseCase,
+          RefreshSessionUseCase,
+          TokenRefreshCoordinator,
+          { provide: AuthRepository, useClass: HttpAuthRepository },
+          { provide: Router, useValue: { url: '/projects/upcoming', navigate: vi.fn() } },
+          {
+            provide: RuntimeConfigService,
+            useValue: { isBearerAuthEnabled: () => false, apiBaseUrl: '/api' },
+          },
+        ],
+      });
+
+      store = TestBed.inject(AuthStore);
+      httpMock = TestBed.inject(HttpTestingController);
     });
 
-    store = TestBed.inject(AuthStore);
-    httpMock = TestBed.inject(HttpTestingController);
+    afterEach(() => {
+      httpMock.verify();
+      localStorage.clear();
+    });
+
+    it('refreshes and replays /auth/me when checkAuthStatus sees an expired access cookie', () => {
+      localStorage.setItem('has_session', 'true');
+
+      store.checkAuthStatus().subscribe();
+
+      httpMock
+        .expectOne('/auth/me')
+        .flush({}, { status: 401, statusText: 'Unauthorized' });
+      httpMock.expectOne('/auth/refresh').flush({});
+      httpMock.expectOne('/auth/me').flush(USER_DTO);
+
+      expect(store.user()).toEqual(expect.objectContaining({
+        id: '1',
+        email: 'test@test.com',
+        username: 'testuser',
+      }));
+      expect(store.isAuthenticated()).toBe(true);
+    });
   });
 
-  afterEach(() => {
-    httpMock.verify();
-    localStorage.clear();
-  });
+  describe('bearer auth', () => {
+    let bearerStore: AuthStore;
+    let bearerHttpMock: HttpTestingController;
 
-  it('refreshes and replays /auth/me when checkAuthStatus sees an expired access cookie', () => {
-    localStorage.setItem('has_session', 'true');
+    beforeEach(() => {
+      TestBed.resetTestingModule();
+      localStorage.clear();
 
-    store.checkAuthStatus().subscribe();
+      TestBed.configureTestingModule({
+        providers: [
+          provideZonelessChangeDetection(),
+          provideHttpClient(withInterceptors([refreshTokenInterceptor, authInterceptor, errorInterceptor])),
+          provideHttpClientTesting(),
+          AuthStore,
+          LoginUseCase,
+          LogoutUseCase,
+          CreateUserUseCase,
+          GetCurrentUserUseCase,
+          UpdateUsernameUseCase,
+          UpdatePasswordUseCase,
+          RefreshSessionUseCase,
+          TokenRefreshCoordinator,
+          { provide: AuthRepository, useClass: HttpAuthRepository },
+          { provide: Router, useValue: { url: '/projects/upcoming', navigate: vi.fn() } },
+          {
+            provide: RuntimeConfigService,
+            useValue: { isBearerAuthEnabled: () => true, apiBaseUrl: 'http://localhost:8080/api' },
+          },
+        ],
+      });
 
-    httpMock
-      .expectOne('/auth/me')
-      .flush({}, { status: 401, statusText: 'Unauthorized' });
-    httpMock.expectOne('/auth/refresh').flush({});
-    httpMock.expectOne('/auth/me').flush(USER_DTO);
+      bearerStore = TestBed.inject(AuthStore);
+      bearerHttpMock = TestBed.inject(HttpTestingController);
+    });
 
-    expect(store.user()).toEqual(expect.objectContaining({
-      id: '1',
-      email: 'test@test.com',
-      username: 'testuser',
-    }));
-    expect(store.isAuthenticated()).toBe(true);
+    afterEach(() => {
+      bearerHttpMock.verify();
+      localStorage.clear();
+    });
+
+    it('refreshes and replays /auth/me when access token is expired', () => {
+      localStorage.setItem('twdist_access_token', 'expired-access');
+      localStorage.setItem('twdist_refresh_token', 'valid-refresh');
+
+      bearerStore.checkAuthStatus().subscribe();
+
+      const meReq = bearerHttpMock.expectOne('/auth/me');
+      expect(meReq.request.headers.get('Authorization')).toBe('Bearer expired-access');
+      meReq.flush({}, { status: 401, statusText: 'Unauthorized' });
+
+      const refreshReq = bearerHttpMock.expectOne('/auth/refresh');
+      expect(refreshReq.request.body).toEqual({ refreshToken: 'valid-refresh' });
+      expect(refreshReq.request.headers.has('Authorization')).toBe(false);
+      refreshReq.flush({
+        user: USER_DTO,
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+      });
+
+      expect(localStorage.getItem('twdist_access_token')).toBe('new-access');
+      expect(localStorage.getItem('twdist_refresh_token')).toBe('new-refresh');
+
+      const replayReq = bearerHttpMock.expectOne('/auth/me');
+      expect(replayReq.request.headers.get('Authorization')).toBe('Bearer new-access');
+      replayReq.flush(USER_DTO);
+
+      expect(bearerStore.isAuthenticated()).toBe(true);
+      expect(localStorage.getItem('twdist_access_token')).toBe('new-access');
+      expect(localStorage.getItem('twdist_refresh_token')).toBe('new-refresh');
+    });
   });
 });

--- a/src/app/features/projects/infrastructure/services/project-events.service.spec.ts
+++ b/src/app/features/projects/infrastructure/services/project-events.service.spec.ts
@@ -1,30 +1,34 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { describe, expect, it, vi } from 'vitest';
+import { of } from 'rxjs';
 
 import { ProjectEventsService } from './project-events.service';
+import { SseRuntimeService } from '@shared/infrastructure/sse/sse-runtime';
 
 describe('ProjectEventsService', () => {
-  const closeSpy = vi.fn();
+  const connectSpy = vi.fn(() => of());
 
   beforeEach(() => {
-    closeSpy.mockClear();
-    vi.stubGlobal(
-      'EventSource',
-      class MockEventSource {
-        addEventListener = vi.fn();
-        close = closeSpy;
-        constructor(public url: string) {}
-      },
+    connectSpy.mockClear();
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        ProjectEventsService,
+        {
+          provide: SseRuntimeService,
+          useValue: { connect: connectSpy },
+        },
+      ],
+    });
+  });
+
+  it('connect() passes project id in SSE path', () => {
+    const service = TestBed.inject(ProjectEventsService);
+    service.connect('42').subscribe();
+    expect(connectSpy).toHaveBeenCalledWith(
+      '/projects/42/events',
+      expect.arrayContaining(['task_created']),
     );
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
-  it('connect(projectId) subscribes to project-scoped URL and closes on teardown', () => {
-    const service = new ProjectEventsService();
-    const sub = service.connect('proj-1').subscribe();
-    sub.unsubscribe();
-    expect(closeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/features/projects/infrastructure/services/project-events.service.ts
+++ b/src/app/features/projects/infrastructure/services/project-events.service.ts
@@ -1,10 +1,11 @@
-import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { environment } from '@shared/config/environment';
+import { Injectable, inject } from '@angular/core';
+import { Observable, map } from 'rxjs';
 import { ProjectEvent, ProjectEventType } from '@features/projects/infrastructure/dto/sse/project-event';
+import { SseRuntimeService } from '@shared/infrastructure/sse/sse-runtime';
 
 @Injectable({ providedIn: 'root' })
 export class ProjectEventsService {
+  private readonly sseRuntime = inject(SseRuntimeService);
 
   private static readonly EVENT_TYPES: ProjectEventType[] = [
     'section_created',
@@ -16,22 +17,11 @@ export class ProjectEventsService {
   ];
 
   connect(projectId: string): Observable<ProjectEvent> {
-    return new Observable(subscriber => {
-      const url = `${environment.apiBaseUrl}/projects/${projectId}/events`;
-      const source = new EventSource(url, { withCredentials: true });
-
-      for (const type of ProjectEventsService.EVENT_TYPES) {
-        source.addEventListener(type, ((e: MessageEvent) => {
-          try {
-            subscriber.next({ type, data: JSON.parse(e.data) });
-          } catch (error) {
-            console.error(`[SSE:Project] Failed to parse "${type}" event:`, error, e.data);
-            subscriber.error(error);
-          }
-        }) as EventListener);
-      }
-
-      return () => source.close();
-    });
+    return this.sseRuntime
+      .connect<ProjectEventType>(
+        `/projects/${projectId}/events`,
+        ProjectEventsService.EVENT_TYPES,
+      )
+      .pipe(map(({ type, data }) => ({ type, data }) as ProjectEvent));
   }
 }

--- a/src/app/features/projects/infrastructure/services/user-events.service.spec.ts
+++ b/src/app/features/projects/infrastructure/services/user-events.service.spec.ts
@@ -1,30 +1,42 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Subject } from 'rxjs';
 
 import { UserEventsService } from './user-events.service';
+import { SseRuntimeService } from '@shared/infrastructure/sse/sse-runtime';
 
 describe('UserEventsService', () => {
-  const closeSpy = vi.fn();
+  const close$ = new Subject<void>();
+  const connectSpy = vi.fn(() => close$.asObservable());
 
   beforeEach(() => {
-    closeSpy.mockClear();
-    vi.stubGlobal(
-      'EventSource',
-      class MockEventSource {
-        addEventListener = vi.fn();
-        close = closeSpy;
-        constructor(public url: string) {}
-      },
-    );
+    connectSpy.mockClear();
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        UserEventsService,
+        {
+          provide: SseRuntimeService,
+          useValue: { connect: connectSpy },
+        },
+      ],
+    });
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
+    close$.complete();
+    TestBed.resetTestingModule();
   });
 
-  it('connect() returns an Observable and closes EventSource on unsubscribe', () => {
-    const service = new UserEventsService();
+  it('connect() delegates to SseRuntimeService and unsubscribes', () => {
+    const service = TestBed.inject(UserEventsService);
     const sub = service.connect().subscribe();
+    expect(connectSpy).toHaveBeenCalledWith('/users/events', [
+      'project_created',
+      'project_updated',
+      'project_deleted',
+    ]);
     sub.unsubscribe();
-    expect(closeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/features/projects/infrastructure/services/user-events.service.ts
+++ b/src/app/features/projects/infrastructure/services/user-events.service.ts
@@ -1,10 +1,11 @@
-import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { environment } from '@shared/config/environment';
+import { Injectable, inject } from '@angular/core';
+import { Observable, map } from 'rxjs';
 import { UserEvent, UserEventType } from '@features/projects/infrastructure/dto/sse/user-event';
+import { SseRuntimeService } from '@shared/infrastructure/sse/sse-runtime';
 
 @Injectable({ providedIn: 'root' })
 export class UserEventsService {
+  private readonly sseRuntime = inject(SseRuntimeService);
 
   private static readonly EVENT_TYPES: UserEventType[] = [
     'project_created',
@@ -13,22 +14,8 @@ export class UserEventsService {
   ];
 
   connect(): Observable<UserEvent> {
-    return new Observable(subscriber => {
-      const url = `${environment.apiBaseUrl}/users/events`;
-      const source = new EventSource(url, { withCredentials: true });
-
-      for (const type of UserEventsService.EVENT_TYPES) {
-        source.addEventListener(type, ((e: MessageEvent) => {
-          try {
-            subscriber.next({ type, data: JSON.parse(e.data) });
-          } catch (error) {
-            console.error(`[SSE:User] Failed to parse "${type}" event:`, error, e.data);
-            subscriber.error(error);
-          }
-        }) as EventListener);
-      }
-
-      return () => source.close();
-    });
+    return this.sseRuntime.connect<UserEventType>('/users/events', UserEventsService.EVENT_TYPES).pipe(
+      map(({ type, data }) => ({ type, data }) as UserEvent),
+    );
   }
 }

--- a/src/app/shared/config/runtime-config.service.ts
+++ b/src/app/shared/config/runtime-config.service.ts
@@ -41,7 +41,7 @@ export class RuntimeConfigService {
 
     const electronConfig = await window.electronAPI.getAppConfig();
     if (!electronConfig?.apiBaseUrl) {
-      if (environment.isElectronRelease) {
+      if (environment.isElectronRelease || this.isElectronShell()) {
         console.error(
           '[RuntimeConfig] Missing electron/config.local.json (or packaged config.json). ' +
             'Copy electron/config.example.json and set apiBaseUrl.',
@@ -59,10 +59,21 @@ export class RuntimeConfigService {
       return this.configFromElectron(syncConfig);
     }
 
+    if (this.isElectronShell()) {
+      return {
+        apiBaseUrl: environment.isElectronRelease ? '' : environment.apiBaseUrl,
+        isBearerAuthEnabled: true,
+      };
+    }
+
     return {
       apiBaseUrl: environment.apiBaseUrl,
       isBearerAuthEnabled: environment.isElectronRelease,
     };
+  }
+
+  private isElectronShell(): boolean {
+    return typeof window !== 'undefined' && !!window.electronAPI;
   }
 
   private getSyncElectronConfig(): ElectronAppConfig | null {

--- a/src/app/shared/infrastructure/sse/sse-connection.ts
+++ b/src/app/shared/infrastructure/sse/sse-connection.ts
@@ -1,0 +1,141 @@
+import { Observable } from 'rxjs';
+
+export interface SseMessage<T extends string = string> {
+  type: T;
+  data: unknown;
+}
+
+export interface SseConnectionOptions {
+  url: string;
+  eventTypes: readonly string[];
+  withCredentials?: boolean;
+  authorizationHeader?: string | null;
+}
+
+/** Opens an SSE stream. Uses fetch when a Bearer token is required (Electron). */
+export function openSseConnection<T extends string>(
+  options: SseConnectionOptions,
+): Observable<SseMessage<T>> {
+  if (options.authorizationHeader) {
+    return openFetchSse<T>(options);
+  }
+  return openNativeEventSource<T>(options);
+}
+
+function openNativeEventSource<T extends string>(
+  options: SseConnectionOptions,
+): Observable<SseMessage<T>> {
+  return new Observable(subscriber => {
+    const source = new EventSource(options.url, {
+      withCredentials: options.withCredentials ?? true,
+    });
+
+    for (const type of options.eventTypes) {
+      source.addEventListener(type, ((event: MessageEvent) => {
+        try {
+          subscriber.next({ type: type as T, data: JSON.parse(event.data) });
+        } catch (error) {
+          console.error(`[SSE] Failed to parse "${type}" event:`, error, event.data);
+          subscriber.error(error);
+        }
+      }) as EventListener);
+    }
+
+    source.onerror = () => subscriber.error(new Error(`SSE connection error: ${options.url}`));
+
+    return () => source.close();
+  });
+}
+
+function openFetchSse<T extends string>(
+  options: SseConnectionOptions,
+): Observable<SseMessage<T>> {
+  return new Observable(subscriber => {
+    const abort = new AbortController();
+
+    void (async () => {
+      try {
+        const response = await fetch(options.url, {
+          method: 'GET',
+          headers: {
+            Accept: 'text/event-stream',
+            Authorization: options.authorizationHeader!,
+          },
+          signal: abort.signal,
+        });
+
+        if (!response.ok) {
+          throw new Error(`SSE request failed (${response.status}): ${options.url}`);
+        }
+
+        const reader = response.body?.getReader();
+        if (!reader) {
+          throw new Error(`SSE response has no body: ${options.url}`);
+        }
+
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            break;
+          }
+
+          buffer += decoder.decode(value, { stream: true });
+          buffer = dispatchSseBuffer(buffer, options.eventTypes, subscriber);
+        }
+      } catch (error) {
+        if (!abort.signal.aborted) {
+          subscriber.error(error);
+        }
+      } finally {
+        subscriber.complete();
+      }
+    })();
+
+    return () => abort.abort();
+  });
+}
+
+function dispatchSseBuffer<T extends string>(
+  buffer: string,
+  eventTypes: readonly string[],
+  subscriber: { next: (value: SseMessage<T>) => void; error: (err: unknown) => void },
+): string {
+  const blocks = buffer.split(/\n\n/);
+  const remainder = blocks.pop() ?? '';
+
+  for (const block of blocks) {
+    if (!block.trim()) {
+      continue;
+    }
+
+    let eventType = 'message';
+    const dataLines: string[] = [];
+
+    for (const line of block.split('\n')) {
+      if (line.startsWith('event:')) {
+        eventType = line.slice(6).trim();
+      } else if (line.startsWith('data:')) {
+        dataLines.push(line.slice(5).trimStart());
+      }
+    }
+
+    if (!eventTypes.includes(eventType) || dataLines.length === 0) {
+      continue;
+    }
+
+    try {
+      subscriber.next({
+        type: eventType as T,
+        data: JSON.parse(dataLines.join('\n')),
+      });
+    } catch (error) {
+      console.error(`[SSE] Failed to parse "${eventType}" event:`, error, dataLines.join('\n'));
+      subscriber.error(error);
+    }
+  }
+
+  return remainder;
+}

--- a/src/app/shared/infrastructure/sse/sse-runtime.ts
+++ b/src/app/shared/infrastructure/sse/sse-runtime.ts
@@ -1,0 +1,30 @@
+import { inject, Injectable } from '@angular/core';
+import { TokenService } from '@features/auth/infrastructure/services/token.service';
+import { RuntimeConfigService } from '@shared/config/runtime-config.service';
+import { openSseConnection, SseConnectionOptions, SseMessage } from '@shared/infrastructure/sse/sse-connection';
+import { buildSseUrl } from '@shared/infrastructure/sse/sse-url';
+import { Observable } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class SseRuntimeService {
+  private readonly runtimeConfig = inject(RuntimeConfigService);
+  private readonly tokenService = inject(TokenService);
+
+  connect<T extends string>(path: string, eventTypes: readonly T[]): Observable<SseMessage<T>> {
+    const url = buildSseUrl(this.runtimeConfig.apiBaseUrl, path);
+    const bearerEnabled = this.tokenService.isBearerAuthEnabled();
+    const accessToken = this.tokenService.getAccessToken();
+
+    const options: SseConnectionOptions = {
+      url,
+      eventTypes,
+      withCredentials: !bearerEnabled,
+      authorizationHeader:
+        bearerEnabled && accessToken
+          ? `Bearer ${accessToken}`
+          : null,
+    };
+
+    return openSseConnection<T>(options);
+  }
+}

--- a/src/app/shared/infrastructure/sse/sse-url.spec.ts
+++ b/src/app/shared/infrastructure/sse/sse-url.spec.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { buildSseUrl } from './sse-url';
+
+describe('buildSseUrl', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('joins base URL and path', () => {
+    expect(buildSseUrl('https://api.example.com/api', '/users/events')).toBe(
+      'https://api.example.com/api/users/events',
+    );
+  });
+
+  it('rejects empty base URL', () => {
+    expect(() => buildSseUrl('', '/users/events')).toThrow(/not configured/i);
+  });
+
+  it('resolves a relative base against http(s) page origin (dev-server proxy)', () => {
+    vi.stubGlobal('window', {
+      location: { protocol: 'http:', origin: 'http://localhost:4200' },
+    });
+
+    expect(buildSseUrl('/api', '/users/events')).toBe(
+      'http://localhost:4200/api/users/events',
+    );
+  });
+
+  it('rejects relative base on non-http origins such as app://', () => {
+    vi.stubGlobal('window', {
+      location: { protocol: 'app:', origin: 'app://.' },
+    });
+
+    expect(() => buildSseUrl('/api', '/users/events')).toThrow(/absolute API base URL/i);
+  });
+});

--- a/src/app/shared/infrastructure/sse/sse-url.ts
+++ b/src/app/shared/infrastructure/sse/sse-url.ts
@@ -1,0 +1,43 @@
+/**
+ * Resolves a relative API base (e.g. `/api`) against the current page origin when running
+ * behind the Angular dev-server proxy (`http://localhost:4200`). EventSource cannot use
+ * HttpClient interceptors, so this mirrors {@link baseUrlInterceptor} for SSE only.
+ */
+export function resolveApiBaseUrlForSse(apiBaseUrl: string): string {
+  const base = apiBaseUrl.replace(/\/$/, '');
+
+  if (!base || base.startsWith('http://') || base.startsWith('https://')) {
+    return base;
+  }
+
+  if (base.startsWith('/') && typeof window !== 'undefined') {
+    const { protocol, origin } = window.location;
+    if (protocol === 'http:' || protocol === 'https:') {
+      return `${origin}${base}`;
+    }
+  }
+
+  return base;
+}
+
+/** Builds an absolute API URL for SSE (EventSource does not use HttpClient interceptors). */
+export function buildSseUrl(apiBaseUrl: string, path: string): string {
+  const base = resolveApiBaseUrlForSse(apiBaseUrl);
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+
+  if (!base) {
+    throw new Error(
+      'API base URL is not configured. Set apiBaseUrl in electron/config.local.json (or packaged config.json).',
+    );
+  }
+
+  const isAbsolute = base.startsWith('http://') || base.startsWith('https://');
+  if (!isAbsolute) {
+    throw new Error(
+      `SSE requires an absolute API base URL (http/https). Got "${apiBaseUrl}". ` +
+        'In packaged Electron, set apiBaseUrl in electron/config.local.json (or packaged config.json).',
+    );
+  }
+
+  return `${base}${normalizedPath}`;
+}

--- a/src/app/shared/interceptors/auth-refresh.util.spec.ts
+++ b/src/app/shared/interceptors/auth-refresh.util.spec.ts
@@ -1,0 +1,65 @@
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+
+import { SessionHintService } from '@features/auth/infrastructure/services/session-hint.service';
+import { TokenService } from '@features/auth/infrastructure/services/token.service';
+import { RuntimeConfigService } from '@shared/config/runtime-config.service';
+import { canAttemptTokenRefresh, isAuthRefreshableStatus } from './auth-refresh.util';
+
+describe('auth-refresh.util', () => {
+  describe('isAuthRefreshableStatus', () => {
+    it('returns true for 401 and 403', () => {
+      expect(isAuthRefreshableStatus(401)).toBe(true);
+      expect(isAuthRefreshableStatus(403)).toBe(true);
+    });
+
+    it('returns false for other statuses', () => {
+      expect(isAuthRefreshableStatus(500)).toBe(false);
+    });
+  });
+
+  describe('canAttemptTokenRefresh', () => {
+    let tokenService: TokenService;
+    let sessionHintService: SessionHintService;
+
+    beforeEach(() => {
+      localStorage.clear();
+      TestBed.configureTestingModule({
+        providers: [
+          provideZonelessChangeDetection(),
+          TokenService,
+          { provide: RuntimeConfigService, useValue: { isBearerAuthEnabled: () => false } },
+        ],
+      });
+      tokenService = TestBed.inject(TokenService);
+      sessionHintService = TestBed.inject(SessionHintService);
+    });
+
+    afterEach(() => {
+      localStorage.clear();
+    });
+
+    it('uses session hint for cookie auth', () => {
+      sessionHintService.markAuthenticated();
+
+      expect(canAttemptTokenRefresh(tokenService, sessionHintService)).toBe(true);
+    });
+
+    it('uses refresh token for bearer auth', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          provideZonelessChangeDetection(),
+          TokenService,
+          { provide: RuntimeConfigService, useValue: { isBearerAuthEnabled: () => true } },
+        ],
+      });
+      tokenService = TestBed.inject(TokenService);
+      sessionHintService = TestBed.inject(SessionHintService);
+      localStorage.setItem('twdist_refresh_token', 'refresh-abc');
+
+      expect(canAttemptTokenRefresh(tokenService, sessionHintService)).toBe(true);
+    });
+  });
+});

--- a/src/app/shared/interceptors/auth-refresh.util.ts
+++ b/src/app/shared/interceptors/auth-refresh.util.ts
@@ -1,0 +1,19 @@
+import { SessionHintService } from '@features/auth/infrastructure/services/session-hint.service';
+import { TokenService } from '@features/auth/infrastructure/services/token.service';
+
+/** HTTP statuses that may indicate an expired or revoked access token (refresh may recover). */
+export function isAuthRefreshableStatus(status: number): boolean {
+  return status === 401 || status === 403;
+}
+
+/** Whether a silent refresh can be attempted for the current auth mode. */
+export function canAttemptTokenRefresh(
+  tokenService: TokenService,
+  sessionHintService: SessionHintService,
+): boolean {
+  if (tokenService.isBearerAuthEnabled()) {
+    return !!tokenService.getRefreshToken();
+  }
+
+  return sessionHintService.hasSessionHint();
+}

--- a/src/app/shared/interceptors/error.interceptor.ts
+++ b/src/app/shared/interceptors/error.interceptor.ts
@@ -1,46 +1,30 @@
-import { HttpErrorResponse, HttpInterceptorFn } from '@angular/common/http';
+import { HttpInterceptorFn } from '@angular/common/http';
 import { inject } from '@angular/core';
-import { EMPTY, catchError, throwError } from 'rxjs';
-import { AuthStore } from '@features/auth/presentation/store/auth.store';
 import { Router } from '@angular/router';
+import { EMPTY } from 'rxjs';
+
 import { SessionHintService } from '@features/auth/infrastructure/services/session-hint.service';
+import { TokenService } from '@features/auth/infrastructure/services/token.service';
+import { canAttemptTokenRefresh } from '@shared/interceptors/auth-refresh.util';
 import { REQUIRES_AUTH } from '@shared/interceptors/auth-context.token';
 
 /**
- * Error Interceptor
- * Catches HTTP responses and globally handles 401 Unauthorized errors 
- * indicating an expired or invalid session token.
+ * Blocks protected requests when there is no restorable session.
+ * Does not handle 401/403 — {@link refreshTokenInterceptor} attempts refresh first;
+ * {@link TokenRefreshCoordinator} clears state and redirects when refresh fails.
  */
 export const errorInterceptor: HttpInterceptorFn = (req, next) => {
-  const authStore = inject(AuthStore);
   const router = inject(Router);
   const sessionHintService = inject(SessionHintService);
+  const tokenService = inject(TokenService);
   const requiresAuth = req.context.get(REQUIRES_AUTH);
-  const hasSessionHint = sessionHintService.hasSessionHint();
 
-  if (requiresAuth && !hasSessionHint) {
+  if (requiresAuth && !canAttemptTokenRefresh(tokenService, sessionHintService)) {
     if (router.url !== '/auth/login') {
       router.navigate(['/auth/login']);
     }
     return EMPTY;
   }
 
-  return next(req).pipe(
-    catchError((error: HttpErrorResponse) => {
-      const isUnauthorized = error.status === 401;
-
-      if (isUnauthorized && requiresAuth) {
-        sessionHintService.clear();
-        authStore.clearSessionState();
-
-        if (router.url !== '/auth/login') {
-          router.navigate(['/auth/login']);
-        }
-
-        return EMPTY;
-      }
-      
-      return throwError(() => error);
-    })
-  );
+  return next(req);
 };

--- a/src/app/shared/interceptors/refresh-token.interceptor.spec.ts
+++ b/src/app/shared/interceptors/refresh-token.interceptor.spec.ts
@@ -11,6 +11,8 @@ import { RefreshSessionUseCase } from '@features/auth/application/use-cases/refr
 import { AuthRepository } from '@features/auth/domain/repositories/auth.repository';
 import { HttpAuthRepository } from '@features/auth/infrastructure/repositories/http-auth.repository';
 import { AuthStore } from '@features/auth/presentation/store/auth.store';
+import { RuntimeConfigService } from '@shared/config/runtime-config.service';
+import { Router } from '@angular/router';
 
 describe('refreshTokenInterceptor', () => {
   let http: HttpClient;
@@ -32,6 +34,11 @@ describe('refreshTokenInterceptor', () => {
         RefreshSessionUseCase,
         { provide: AuthRepository, useClass: HttpAuthRepository },
         { provide: AuthStore, useValue: authStoreMock },
+        { provide: Router, useValue: { url: '/projects/upcoming', navigate: vi.fn() } },
+        {
+          provide: RuntimeConfigService,
+          useValue: { isBearerAuthEnabled: () => false, apiBaseUrl: '/api' },
+        },
       ],
     });
 
@@ -45,6 +52,7 @@ describe('refreshTokenInterceptor', () => {
   });
 
   it('refreshes once and replays the original request after a protected 401', () => {
+    localStorage.setItem('has_session', 'true');
     let result: unknown;
 
     http.get('/projects/get', requiresAuthContext()).subscribe((response) => (result = response));
@@ -65,6 +73,7 @@ describe('refreshTokenInterceptor', () => {
   });
 
   it('queues concurrent protected 401s behind one refresh request', () => {
+    localStorage.setItem('has_session', 'true');
     const results: unknown[] = [];
 
     http.get('/projects/get', requiresAuthContext()).subscribe((response) => results.push(response));
@@ -136,7 +145,23 @@ describe('refreshTokenInterceptor', () => {
     expect(emittedError?.status).toBe(401);
   });
 
+  it('refreshes on 403 when a session can be restored', () => {
+    localStorage.setItem('has_session', 'true');
+    let result: unknown;
+
+    http.get('/projects/get', requiresAuthContext()).subscribe((response) => (result = response));
+
+    httpMock
+      .expectOne('/projects/get')
+      .flush({}, { status: 403, statusText: 'Forbidden' });
+    httpMock.expectOne('/auth/refresh').flush({});
+    httpMock.expectOne('/projects/get').flush({ ok: true });
+
+    expect(result).toEqual({ ok: true });
+  });
+
   it('retries each protected request only once', () => {
+    localStorage.setItem('has_session', 'true');
     let emittedError: HttpErrorResponse | undefined;
 
     http.get('/projects/get', requiresAuthContext()).subscribe({

--- a/src/app/shared/interceptors/refresh-token.interceptor.ts
+++ b/src/app/shared/interceptors/refresh-token.interceptor.ts
@@ -3,6 +3,12 @@ import { inject } from '@angular/core';
 import { catchError, switchMap, throwError } from 'rxjs';
 
 import { TokenRefreshCoordinator } from '@features/auth/application/services/token-refresh-coordinator.service';
+import { SessionHintService } from '@features/auth/infrastructure/services/session-hint.service';
+import { TokenService } from '@features/auth/infrastructure/services/token.service';
+import {
+  canAttemptTokenRefresh,
+  isAuthRefreshableStatus,
+} from '@shared/interceptors/auth-refresh.util';
 import { REQUIRES_AUTH } from '@shared/interceptors/auth-context.token';
 
 export const RETRIED_AFTER_REFRESH = new HttpContextToken<boolean>(() => false);
@@ -11,6 +17,8 @@ const REFRESH_EXCLUDED_AUTH_PATHS = ['/auth/refresh', '/auth/login', '/auth/sign
 
 export const refreshTokenInterceptor: HttpInterceptorFn = (req, next) => {
   const coordinator = inject(TokenRefreshCoordinator);
+  const tokenService = inject(TokenService);
+  const sessionHintService = inject(SessionHintService);
   const requiresAuth = req.context.get(REQUIRES_AUTH);
   const alreadyRetried = req.context.get(RETRIED_AFTER_REFRESH);
 
@@ -20,15 +28,23 @@ export const refreshTokenInterceptor: HttpInterceptorFn = (req, next) => {
 
   return next(req).pipe(
     catchError((error: unknown) => {
-      if (!(error instanceof HttpErrorResponse) || error.status !== 401) {
+      if (!(error instanceof HttpErrorResponse) || !isAuthRefreshableStatus(error.status)) {
+        return throwError(() => error);
+      }
+
+      if (!canAttemptTokenRefresh(tokenService, sessionHintService)) {
         return throwError(() => error);
       }
 
       return coordinator.runRefresh().pipe(
         catchError(() => throwError(() => error)),
-        switchMap(() => next(req.clone({
-          context: req.context.set(RETRIED_AFTER_REFRESH, true),
-        }))),
+        switchMap(() =>
+          next(
+            req.clone({
+              context: req.context.set(RETRIED_AFTER_REFRESH, true),
+            }),
+          ),
+        ),
       );
     }),
   );


### PR DESCRIPTION
With the previous refactors in PRs #129 and #130, when reloading the page the session was lost.

Fixed this and also fixed the current refresh logic. Now, everything related with auth works perfectly fine. 

Next steps will be the refactor of changing the tokens storage from the localStorage to the secure options.

---

AI summary:

This pull request introduces several improvements and refactorings across authentication, session management, and server-sent events (SSE) handling. The most significant changes include enhanced support for bearer authentication, more robust token handling, improved session hint logic, and a refactor of SSE services to use a shared runtime service. Additionally, the test suites have been updated to reflect these changes and to improve coverage for both bearer and cookie authentication modes.

**Authentication and Token Management Enhancements:**

- Improved bearer authentication detection: The `TokenService` and `SessionHintService` now more reliably detect bearer authentication mode, even if the runtime config is not immediately available, by checking for tokens in local storage. This ensures smoother transitions and fewer edge case failures. [[1]](diffhunk://#diff-89cd591cfb98f52f8d93deb98a043b19930f2b1825ea4bb4dd3d0f0b058d81a4L17-R25) [[2]](diffhunk://#diff-0a912111f919aebf31f1792c853a09f1e3edae0a640f4994320949da7ceff9c4L1-R18)
- More robust token normalization and storage: The `HttpAuthRepository` now normalizes token fields to support both camelCase and snake_case, strips "Bearer" prefixes, and ensures tokens are stored consistently.
- Improved error handling during authentication: The `/auth/me` endpoint no longer clears the local session on error, preventing unwanted logouts when bearer tokens are missing or expired.
- The application bootstrap now properly awaits authentication status, ensuring that the app waits for `/auth/me` before finishing initialization.

**Session Hint Logic:**

- The `SessionHintService` now considers the presence of bearer tokens as a session hint, improving compatibility with bearer authentication flows.
- Unit tests for `SessionHintService` have been expanded to cover bearer auth scenarios.

**SSE (Server-Sent Events) Refactor:**

- Both `ProjectEventsService` and `UserEventsService` have been refactored to delegate SSE connection logic to a shared `SseRuntimeService`, simplifying the code and centralizing SSE handling. [[1]](diffhunk://#diff-0c2489bcf7bda038fe9a1f061a615eaa973efedfac2d6b3a0ddf08c3be985a07L1-R8) [[2]](diffhunk://#diff-a24bdf309159d0bdee0dc5206ca0339499ac84a794c3b6a8036b46b926ebea72L1-L28)
- Corresponding tests have been updated to use Angular's `TestBed` and to mock the `SseRuntimeService` rather than relying on global stubs. [[1]](diffhunk://#diff-04b2ad5dad2bb1448edc092b352851d7b90078dd13293f9598c367b045e570f5L1-R32) [[2]](diffhunk://#diff-a24bdf309159d0bdee0dc5206ca0339499ac84a794c3b6a8036b46b926ebea72L1-L28)

**Testing Improvements:**

- Integration and unit tests have been expanded to cover both cookie-based and bearer-based authentication, including token refresh flows and session hints. [[1]](diffhunk://#diff-0c320108336fb1432c5e4653ff0f1426b9d9ffa6382eb7b36200fab36cef375dR90-R162) [[2]](diffhunk://#diff-94bd03e9ce940960de21adf6262d37f7f6c09f155ab93163b924b824848f571fR81-R104)
- Test configuration has been improved for better isolation and reliability, including proper teardown and use of Angular dependency injection. [[1]](diffhunk://#diff-0c320108336fb1432c5e4653ff0f1426b9d9ffa6382eb7b36200fab36cef375dR55-R58) [[2]](diffhunk://#diff-04b2ad5dad2bb1448edc092b352851d7b90078dd13293f9598c367b045e570f5L1-R32)

**Router and Interceptor Adjustments:**

- The order of HTTP interceptors has been corrected to ensure the `refreshTokenInterceptor` runs before others, preventing issues with token refresh logic.
- The `TokenRefreshCoordinator` now injects the `Router` directly and navigates to `/auth/login` on refresh failure, improving user experience on authentication errors. [[1]](diffhunk://#diff-dc830cefc0d643af43fc880f0cf8226387fa3edef3ceb0932b555308b06ec9fdR18) [[2]](diffhunk://#diff-dc830cefc0d643af43fc880f0cf8226387fa3edef3ceb0932b555308b06ec9fdR45-R48)

---

**Authentication and Token Management**
- Improved bearer auth detection and token storage logic in `TokenService` and `HttpAuthRepository`, including normalization of token fields and support for both camelCase and snake_case. [[1]](diffhunk://#diff-89cd591cfb98f52f8d93deb98a043b19930f2b1825ea4bb4dd3d0f0b058d81a4L17-R25) [[2]](diffhunk://#diff-f969916ea5c0159ed106bbc6f0cf359fd3ce97af9dd91ea0f667203d5a79ad60L136-R152)
- `/auth/me` endpoint error handling updated to avoid clearing local session on error, supporting smoother token refresh flows.
- Application bootstrap now properly awaits authentication checks, ensuring initialization waits for `/auth/me`.
- Corrected HTTP interceptor order to ensure `refreshTokenInterceptor` runs first.

**Session Hint Logic**
- `SessionHintService` now considers stored bearer tokens as a session hint, with expanded tests for bearer auth scenarios. [[1]](diffhunk://#diff-0a912111f919aebf31f1792c853a09f1e3edae0a640f4994320949da7ceff9c4L1-R18) [[2]](diffhunk://#diff-94bd03e9ce940960de21adf6262d37f7f6c09f155ab93163b924b824848f571fR81-R104)

**SSE Refactor**
- `ProjectEventsService` and `UserEventsService` refactored to use `SseRuntimeService` for SSE connections, simplifying code and centralizing SSE logic. [[1]](diffhunk://#diff-0c2489bcf7bda038fe9a1f061a615eaa973efedfac2d6b3a0ddf08c3be985a07L1-R8) [[2]](diffhunk://#diff-a24bdf309159d0bdee0dc5206ca0339499ac84a794c3b6a8036b46b926ebea72L1-L28)
- Updated tests for SSE services to use Angular's `TestBed` and mock `SseRuntimeService`. [[1]](diffhunk://#diff-04b2ad5dad2bb1448edc092b352851d7b90078dd13293f9598c367b045e570f5L1-R32) [[2]](diffhunk://#diff-a24bdf309159d0bdee0dc5206ca0339499ac84a794c3b6a8036b46b926ebea72L1-L28)

**Testing Improvements**
- Expanded integration and unit tests for both cookie and bearer authentication modes, including token refresh and session hint scenarios. [[1]](diffhunk://#diff-0c320108336fb1432c5e4653ff0f1426b9d9ffa6382eb7b36200fab36cef375dR90-R162) [[2]](diffhunk://#diff-94bd03e9ce940960de21adf6262d37f7f6c09f155ab93163b924b824848f571fR81-R104)
- Improved test configuration and teardown for reliability and isolation. [[1]](diffhunk://#diff-0c320108336fb1432c5e4653ff0f1426b9d9ffa6382eb7b36200fab36cef375dR55-R58) [[2]](diffhunk://#diff-04b2ad5dad2bb1448edc092b352851d7b90078dd13293f9598c367b045e570f5L1-R32)

**Router and Navigation**
- `TokenRefreshCoordinator` now injects `Router` and navigates to `/auth/login` on refresh failure, improving handling of authentication errors. [[1]](diffhunk://#diff-dc830cefc0d643af43fc880f0cf8226387fa3edef3ceb0932b555308b06ec9fdR18) [[2]](diffhunk://#diff-dc830cefc0d643af43fc880f0cf8226387fa3edef3ceb0932b555308b06ec9fdR45-R48)