### PR TITLE
Fix/auto releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release Build
 
 on:
   push:
-    branches: [ main ]
+    branches: [ fix/auto-releases ]
 
 jobs:
   build-linux:
@@ -25,6 +25,11 @@ jobs:
 
       - name: Compile Electron TypeScript
         run: bun run electron:tsc
+
+      - name: Generate packaged API config
+        run: bun run electron:config
+        env:
+          TWDIST_API_BASE_URL: ${{ secrets.TWDIST_API_BASE_URL }}
 
       - name: Package with electron-builder (Linux)
         run: bunx electron-builder --linux --publish never
@@ -58,6 +63,11 @@ jobs:
 
       - name: Compile Electron TypeScript
         run: bun run electron:tsc
+
+      - name: Generate packaged API config
+        run: bun run electron:config
+        env:
+          TWDIST_API_BASE_URL: ${{ secrets.TWDIST_API_BASE_URL }}
 
       - name: Package with electron-builder (Windows)
         run: bunx electron-builder --win --publish never

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release Build
 
 on:
   push:
-    branches: [ fix/auto-releases ]
+    branches: [ main ]
 
 jobs:
   build-linux:

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -148,7 +148,18 @@ bun run electron:build
 
 Artifacts appear under `release/`.
 
-**CI note:** GitHub Actions release workflow should set `TWDIST_API_BASE_URL` from a repository secret and run `bun run electron:config` before `electron-builder` so installers include the correct API URL. That secret is not stored in git.
+### GitHub Releases (CI)
+
+Installers built by [`.github/workflows/release.yml`](../.github/workflows/release.yml) **do not** read `config.local.json`. They embed API settings from a repository secret at build time.
+
+1. In the repo: **Settings → Secrets and variables → Actions → New repository secret**
+2. Name: **`TWDIST_API_BASE_URL`**
+3. Value: absolute API base URL, including the `/api` suffix, e.g.  
+   `https://twdist-back-123456789.europe-west9.run.app/api`
+
+On each push to `main`, the release workflow runs `bun run electron:config` (writes gitignored `electron/config.packaged.json`) and then `electron-builder`, which copies it to `resources/config.json` inside the `.AppImage` / `.exe` / `.deb`.
+
+If the secret is missing or empty, the config step fails in CI and no broken release is published. If you see the runtime error in an **older** release artifact, that build was produced before this step was wired in — trigger a new release after merging the workflow fix and setting the secret.
 
 ---
 


### PR DESCRIPTION
Now properly configuring the backend url before publishing the production ready app.

Tried the new release and it now works just fine.

---

AI Summary:

This pull request updates the release workflow and documentation to ensure that Electron installers are built with the correct API configuration, securely sourced from repository secrets. The changes add a new build step to generate the packaged API config and clarify the process in the documentation.

**Workflow improvements:**

* Added a `Generate packaged API config` step to the Electron build process in `.github/workflows/release.yml`, which runs `bun run electron:config` and injects the `TWDIST_API_BASE_URL` from a repository secret for both Linux and Windows builds. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R29-R33) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R67-R71)

**Documentation updates:**

* Expanded the `docs/local-development.md` to clearly explain how the release workflow embeds API settings from the `TWDIST_API_BASE_URL` secret, the steps to add this secret, and the importance of this step for correct installer configuration.